### PR TITLE
Add support for a single string as the second argument to alias

### DIFF
--- a/djunc/projectors.py
+++ b/djunc/projectors.py
@@ -43,16 +43,31 @@ def combine(*projectors):
     return combined
 
 
-def alias(projector, aliases):
+def alias(projector, alias_or_aliases):
     """
     Given a projector and a dictionary of aliases {"old_key_name": "new_key_name"},
     return a projector which replaces the keys in the output of the original projector
-    with those provided in the alias map.
+    with those provided in the alias map. As a shortcut, the argument can be a single
+    string, in which case this will automatically alias a single-key projector without
+    needing to know the key name of key in the dictionary returned from the
+    inner projector.
     """
 
     def aliaser(instance):
         projected = projector(instance)
-        for old, new in aliases.items():
+        if isinstance(alias_or_aliases, str) and len(projected) != 1:
+            raise TypeError(
+                "A single string can only be used as an alias for projectors "
+                "that return a dictionary with a single key. Please use a mapping "
+                "to define aliases instead."
+            )
+
+        alias_map = (
+            {next(iter(projected)): alias_or_aliases}
+            if isinstance(alias_or_aliases, str)
+            else alias_or_aliases
+        )
+        for old, new in alias_map.items():
             projected[new] = projected.pop(old)
         return projected
 

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -31,6 +31,22 @@ class ProjectorTestCase(TestCase):
         result = project(widget)
         self.assertEqual(result, {"new_name": "test"})
 
+    def test_single_alias(self):
+        widget = Widget.objects.create(name="test")
+        project = projectors.alias(projectors.field("name"), "new_name")
+        result = project(widget)
+        self.assertEqual(result, {"new_name": "test"})
+
+    def test_single_alias_with_multiple_keys(self):
+        widget = Widget.objects.create(name="test")
+
+        def projector(_):
+            return {"a": 1, "b": 2}
+
+        project = projectors.alias(projector, "aliased")
+        with self.assertRaises(TypeError):
+            project(widget)
+
 
 class RelationshipTestCase(TestCase):
     def test_relationship_projector(self):


### PR DESCRIPTION
This only works if the projector returns dictionary with a single key.