### PR TITLE
Pair functions now take pairs as arguments, rather than each item separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Relationships can automatically be loaded and projected, too:
 prepare, project = pairs.combine(
     pairs.field("name"),
     age_pair,
-    pairs.auto_relationship("book_set", *pairs.combine(
+    pairs.auto_relationship("book_set", pairs.combine(
         pairs.field("title"),
         pairs.field("publication_year"),
     ))

--- a/djunc/pairs.py
+++ b/djunc/pairs.py
@@ -21,7 +21,8 @@ def combine(*pairs):
     return qs.pipe(*prepare_fns), projectors.combine(*project_fns)
 
 
-def alias(alias_or_aliases, prepare, project):
+def alias(alias_or_aliases, pair):
+    prepare, project = pair
     return prepare, projectors.alias(alias_or_aliases, project)
 
 
@@ -63,31 +64,28 @@ doing something weird, like providing a custom queryset.
 """
 
 
-def forward_relationship(
-    name, related_queryset, prepare_related_queryset, project_relationship
-):
+def forward_relationship(name, related_queryset, relationship_pair):
+    prepare_related_queryset, project_relationship = relationship_pair
     related_queryset = prepare_related_queryset(related_queryset)
     prepare = qs.prefetch_forward_relationship(name, related_queryset)
     return prepare, projectors.relationship(name, project_relationship)
 
 
-def reverse_relationship(
-    name, related_name, related_queryset, prepare_related_queryset, project_relationship
-):
+def reverse_relationship(name, related_name, related_queryset, relationship_pair):
+    prepare_related_queryset, project_relationship = relationship_pair
     related_queryset = prepare_related_queryset(related_queryset)
     prepare = qs.prefetch_reverse_relationship(name, related_name, related_queryset)
     return prepare, projectors.relationship(name, project_relationship)
 
 
-def many_to_many_relationship(
-    name, related_queryset, prepare_related_queryset, project_relationship
-):
+def many_to_many_relationship(name, related_queryset, relationship_pair):
+    prepare_related_queryset, project_relationship = relationship_pair
     related_queryset = prepare_related_queryset(related_queryset)
     prepare = qs.prefetch_many_to_many_relationship(name, related_queryset)
     return prepare, projectors.relationship(name, project_relationship)
 
 
-def auto_relationship(name, prepare_related_queryset, project_relationship):
+def auto_relationship(name, relationship_pair):
     """
     Given the name of a relationship, return a prepare function which introspects the
     relationship to discover its type and generates the correct set of
@@ -99,6 +97,7 @@ def auto_relationship(name, prepare_related_queryset, project_relationship):
     inconsistent: each type has a slightly different way of accessing its related
     queryset, the name of the field on the other side of the relationship, etc.
     """
+    prepare_related_queryset, project_relationship = relationship_pair
 
     def prepare(queryset):
         related_descriptor = getattr(queryset.model, name)

--- a/djunc/spec.py
+++ b/djunc/spec.py
@@ -7,7 +7,7 @@ def process_item(item):
         return pairs.field(item)
     if isinstance(item, dict):
         for name, child_spec in item.items():
-            return pairs.auto_relationship(name, *process(child_spec))
+            return pairs.auto_relationship(name, process(child_spec))
     return item
 
 
@@ -16,4 +16,4 @@ def process(spec):
 
 
 def alias(alias_or_aliases, item):
-    return pairs.alias(alias_or_aliases, *process_item(item))
+    return pairs.alias(alias_or_aliases, process_item(item))

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -35,12 +35,12 @@ class PairsTestCase(TestCase):
             pairs.forward_relationship(
                 "owner",
                 Owner.objects.all(),
-                *pairs.combine(
+                pairs.combine(
                     pairs.field("name"),
                     pairs.forward_relationship(
                         "group",
                         Group.objects.all(),
-                        *pairs.field("name"),
+                        pairs.field("name"),
                     ),
                 ),
             ),
@@ -77,13 +77,13 @@ class PairsTestCase(TestCase):
                 "owner_set",
                 "group",
                 Owner.objects.all(),
-                *pairs.combine(
+                pairs.combine(
                     pairs.field("name"),
                     pairs.reverse_relationship(
                         "widget_set",
                         "owner",
                         Widget.objects.all(),
-                        *pairs.field("name"),
+                        pairs.field("name"),
                     ),
                 ),
             ),
@@ -129,13 +129,13 @@ class PairsTestCase(TestCase):
             pairs.forward_relationship(
                 "widget",
                 Widget.objects.all(),
-                *pairs.combine(
+                pairs.combine(
                     pairs.field("name"),
                     pairs.reverse_relationship(
                         "thing",
                         "widget",
                         Thing.objects.all(),
-                        *pairs.field("name"),
+                        pairs.field("name"),
                     ),
                 ),
             ),
@@ -168,12 +168,12 @@ class PairsTestCase(TestCase):
             pairs.many_to_many_relationship(
                 "widget_set",
                 Widget.objects.all(),
-                *pairs.combine(
+                pairs.combine(
                     pairs.field("name"),
                     pairs.many_to_many_relationship(
                         "category_set",
                         Category.objects.all(),
-                        *pairs.field("name"),
+                        pairs.field("name"),
                     ),
                 ),
             ),
@@ -209,26 +209,26 @@ class PairsTestCase(TestCase):
             pairs.field("name"),
             pairs.auto_relationship(
                 "owner",
-                *pairs.combine(
+                pairs.combine(
                     pairs.field("name"),
                     pairs.auto_relationship(
                         "widget_set",
-                        *pairs.field("name"),
+                        pairs.field("name"),
                     ),
                 ),
             ),
             pairs.auto_relationship(
                 "category_set",
-                *pairs.combine(
+                pairs.combine(
                     pairs.field("name"),
-                    pairs.auto_relationship("widget_set", *pairs.field("name")),
+                    pairs.auto_relationship("widget_set", pairs.field("name")),
                 ),
             ),
             pairs.auto_relationship(
                 "thing",
-                *pairs.combine(
+                pairs.combine(
                     pairs.field("name"),
-                    pairs.auto_relationship("widget", *pairs.field("name")),
+                    pairs.auto_relationship("widget", pairs.field("name")),
                 ),
             ),
         )
@@ -262,12 +262,12 @@ class PairsTestCase(TestCase):
         Widget.objects.create(name="test widget", owner=owner)
 
         prepare, project = pairs.combine(
-            pairs.alias("name_alias", *pairs.field("name")),
+            pairs.alias("name_alias", pairs.field("name")),
             pairs.alias(
                 {"widget_set": "widgets"},
-                *pairs.auto_relationship(
+                pairs.auto_relationship(
                     "widget_set",
-                    *pairs.alias({"name": "alias"}, *pairs.field("name")),
+                    pairs.alias({"name": "alias"}, pairs.field("name")),
                 ),
             ),
         )


### PR DESCRIPTION
Before, it was necessary to unpack pairs (with `*`) when passing them into pair functions, eg:

```python
prepare, project = pairs.combine(
    pairs.field("name"),
    pairs.forward_relationship(
        "owner",
        Owner.objects.all(),
        *pairs.combine(
            pairs.field("name"),
            pairs.forward_relationship(
                "group",
                Group.objects.all(),
                *pairs.field("name"),
            ),
        ),
    ),
)
```

Now, the pair functions take the pair itself as their last argument and unpack it themselves:

```python
prepare, project = pairs.combine(
    pairs.field("name"),
    pairs.forward_relationship(
        "owner",
        Owner.objects.all(),
        pairs.combine(
            pairs.field("name"),
            pairs.forward_relationship(
                "group",
                Group.objects.all(),
                pairs.field("name"),
            ),
        ),
    ),
)
```

I _think_ this is nicer and more consistent - I like the symmetry of functions that return a pair also taking a pair. Thoughts welcomed!