### PR TITLE
Add pairs.filter shortcut function

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,24 @@ prepare, project = pairs.alias(
 )
 ```
 
+As a shortcut, the `pairs` module provides a function called `filter`, which can be used to apply a filter to the queryset without affecting the projection. This is equivalent to `(qs.filter(arg=value), projectors.noop)` and is most useful for filtering related objects:
+
+```python
+prepare, project = pairs.combine(
+    pairs.field("name"),
+    age_pair,
+    pairs.auto_relationship(
+        "book_set",
+        pairs.combine(
+            pairs.filter(publication_year__gte=2020),
+            pairs.field("title"),
+            pairs.field("publication_year"),
+        ),
+        to_attr="recent_books"
+    )
+)
+```
+
 ### `djunc.specs`: a high-level specification for efficient data querying and projection
 
 This layer is the real magic of `djunc`: a straightforward way of specifying the shape of your data in order to efficiently select and project a complex tree of related objects.

--- a/djunc/pairs.py
+++ b/djunc/pairs.py
@@ -27,6 +27,10 @@ def project_only(project):
     return qs.noop, project
 
 
+def filter(*args, **kwargs):
+    return prepare_only(qs.filter(*args, **kwargs))
+
+
 """
 Below are pair functions which wrap the various queryset functions that prefetch
 relationships of various types, and then project those related objects.

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -474,3 +474,19 @@ class PairsTestCase(TestCase):
         self.assertEqual(
             result, {"name": "test widget", "owner": {"name": "test owner"}}
         )
+
+
+class FilterTestCase(TestCase):
+    def test_filter(self):
+        Widget.objects.create(name="first")
+        Widget.objects.create(name="second")
+
+        prepare, project = pairs.combine(
+            pairs.filter(name="first"),
+            pairs.field("name"),
+        )
+
+        queryset = prepare(Widget.objects.all())
+        self.assertEqual(len(queryset), 1)
+        result = project(queryset.first())
+        self.assertEqual(result, {"name": "first"})


### PR DESCRIPTION
This adds `pairs.filter` which is equivalent to `(qs.filter(...), projectors.noop)`.

Open question: do we also need `pairs.exclude`, `pairs.order_by` etc, or are these sufficiently rare requirements that we're OK with sticking with the "lower level" versions?