### PR TITLE
Rename projectors.field to projectors.attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ print(project_age(author))
 #  {'age': 37}
 ```
 
-The simplest projector is one that returns the value of a model field, wrapped in a dictionary with the field name as its single key. `djunc` provides a projector that does this:
+The simplest projector is one that returns the value of an object attribute, wrapped in a dictionary with the attribute name as its single key. `djunc` provides a projector that does this:
 
 ```python
 from djunc import projectors
 
 author = Author(name="Some Author")
-project = projectors.field("name")
+project = projectors.attr("name")
 print(project(author))
 #  {'name': 'Some Author'}
 ```
@@ -118,7 +118,7 @@ Projectors can be combined. The keys and values from the dictionary returned by 
 from djunc import projectors
 
 project = projectors.combine(
-    projectors.field("name"),
+    projectors.attr("name"),
     project_age,
 )
 print(project(author))
@@ -129,11 +129,11 @@ Related objects can also be projected using the `projectors.relationship` functi
 
 ```python
 project = projectors.combine(
-    projectors.field("name"),
+    projectors.attr("name"),
     project_age,
     projectors.relationship("book_set", projectors.combine(
-        projectors.field("title"),
-        projectors.field("publication_year"),
+        projectors.attr("title"),
+        projectors.attr("publication_year"),
     )),
 )
 print(project(author))
@@ -144,7 +144,7 @@ Projectors can also be aliased, which means replacing one or more keys in the re
 
 ```python
 project = projectors.alias(
-    "year_of_birth", projectors.field("birth_year")
+    "year_of_birth", projectors.attr("birth_year")
 )
 ```
 

--- a/djunc/pairs.py
+++ b/djunc/pairs.py
@@ -2,7 +2,7 @@ from djunc import projectors, qs
 
 
 def field(name):
-    return qs.include_fields(name), projectors.field(name)
+    return qs.include_fields(name), projectors.attr(name)
 
 
 def combine(*pairs):

--- a/djunc/projectors.py
+++ b/djunc/projectors.py
@@ -9,7 +9,7 @@ def wrap(key, value_getter):
     return projector
 
 
-def field(name):
+def attr(name):
     return wrap(name, attrgetter(name))
 
 

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -458,7 +458,7 @@ class PairsTestCase(TestCase):
             ),
             pairs.field("name"),
             pairs.project_only(
-                projectors.relationship("owner", projectors.field("name"))
+                projectors.relationship("owner", projectors.attr("name"))
             ),
         )
 

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -4,17 +4,17 @@ from tests.models import Group, Owner, Widget
 
 
 class ProjectorTestCase(TestCase):
-    def test_field(self):
+    def test_attr(self):
         widget = Widget.objects.create(name="test")
-        project = projectors.field("name")
+        project = projectors.attr("name")
         result = project(widget)
         self.assertEqual(result, {"name": "test"})
 
     def test_combine(self):
         widget = Widget.objects.create(name="test", other="other")
         project = projectors.combine(
-            projectors.field("name"),
-            projectors.field("other"),
+            projectors.attr("name"),
+            projectors.attr("other"),
         )
         result = project(widget)
         self.assertEqual(result, {"name": "test", "other": "other"})
@@ -27,13 +27,13 @@ class ProjectorTestCase(TestCase):
 
     def test_alias(self):
         widget = Widget.objects.create(name="test")
-        project = projectors.alias({"name": "new_name"}, projectors.field("name"))
+        project = projectors.alias({"name": "new_name"}, projectors.attr("name"))
         result = project(widget)
         self.assertEqual(result, {"new_name": "test"})
 
     def test_single_alias(self):
         widget = Widget.objects.create(name="test")
-        project = projectors.alias("new_name", projectors.field("name"))
+        project = projectors.alias("new_name", projectors.attr("name"))
         result = project(widget)
         self.assertEqual(result, {"new_name": "test"})
 
@@ -58,12 +58,12 @@ class RelationshipTestCase(TestCase):
         )
 
         project = projectors.combine(
-            projectors.field("name"),
+            projectors.attr("name"),
             projectors.relationship(
                 "owner",
                 projectors.combine(
-                    projectors.field("name"),
-                    projectors.relationship("group", projectors.field("name")),
+                    projectors.attr("name"),
+                    projectors.relationship("group", projectors.attr("name")),
                 ),
             ),
         )
@@ -86,12 +86,12 @@ class RelationshipTestCase(TestCase):
         Widget.objects.create(name="widget 3", owner=owner_2)
 
         project = projectors.combine(
-            projectors.field("name"),
+            projectors.attr("name"),
             projectors.relationship(
                 "owner_set",
                 projectors.combine(
-                    projectors.field("name"),
-                    projectors.relationship("widget_set", projectors.field("name")),
+                    projectors.attr("name"),
+                    projectors.relationship("widget_set", projectors.attr("name")),
                 ),
             ),
         )


### PR DESCRIPTION
This is a better name because it more correctly describes what the projector does: it gets an attribute from an object. The attribute may not always be a field. "Field" is really a Django term, so it still makes sense for the `pairs.field` function to be named as it is, because _in that case_ the attribute in question is indeed a field. But in _general_ `projectors.attr` could be getting any kind of attribute.

It also more nicely mirrors the naming convention in #16 - `projectors.attr` uses `attrgetter` and `projectors.method` uses `methodcaller`.