### PR TITLE
Handle the case where the same relationship is used multiple times in a spec

### DIFF
--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -131,3 +131,31 @@ class SpecTestCase(TestCase):
         self.assertEqual(
             result, {"name_alias": "test owner", "widgets": [{"alias": "test widget"}]}
         )
+
+    def test_multiple_instances_of_the_same_relationship(self):
+        Thing.objects.create(
+            name="test thing",
+            size="L",
+            widget=Widget.objects.create(name="test widget"),
+        )
+
+        prepare, project = specs.process(
+            [
+                "name",
+                {"thing": ["name"]},
+                specs.alias("other_thing", {"thing": ["size"]}),
+            ]
+        )
+
+        queryset = prepare(Widget.objects.all())
+        instance = queryset.first()
+        result = project(instance)
+
+        self.assertEqual(
+            result,
+            {
+                "name": "test widget",
+                "thing": {"name": "test thing"},
+                "other_thing": {"size": "L"},
+            },
+        )


### PR DESCRIPTION
Imagine that for some reason you want the following projection of a `Book` (which has a foreign key `author` to `Author`):

```
{
    "name": "django-readers for Dummies",
    "author": {"name": "Jamie"},
    "writer": {"year_of_birth": 1984},
}
```

You might write the following spec:

```
spec = [
    "name",
    {"author": ["name"]},
    specs.alias("writer": {"author": ["year_of_birth"]}),
]
```

This might seem like an odd thing to do (and it probably is) but I think you'd expect it to work.

What happens at the moment is you get

```
ValueError: 'author' lookup was already seen with a different queryset. You may need to adjust the ordering of your lookups.
```

This is because the two relationships are (I think rightly) treated entirely independently, and so a `prefetch_related` is generated for each one. But - because the underlying relationship name (`author`) is the same, the two prefetches clash and :boom:

This PR automatically creates a UUID-based `to_attr` for every `auto_relationship` (and therefore every `{"something": ["whatever"]}` used in a spec). This means the `prefetch_related` calls no longer clash. The projector is then wrapped in an `alias` call which converts the random attribute back to the "real" name.

The motivation for this, by the way, came from trying to convert SSM to use django-readers. One of the test cases has the following spec:

```
...
    {'class_name': ClassName()},
    {'clasz': [
        {'num_students': CountOf('student')},
    ]},
...
```

where `ClassName` is a plugin like this:

```
class ClassName(SerializationSpecPlugin):
    serialization_spec = [
        {'clasz': [
            'name',
            {'teacher': [
                'name'
            ]},
        ]},
    ]

    def get_value(self, instance):
        return '%s - %s' % (instance.clasz.name, instance.clasz.teacher.name)
```

Here the two claszes are claszhing.

EDIT: Hrm. The plugin example doesn't actually work, because `get_value` is expecting `instance.clasz` to be a thing, and it isn't, instead it's `instance._django_readers_prefetch_<some uuid>`. There's no way for `get_value` to obtain the property name (and it wouldn't make sense anyway). Hrm.