### PR TITLE
Expose auto_relationship in the specs module to allow passing to_attr if needed

### DIFF
--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -8,8 +8,8 @@ def process_item(item):
     if isinstance(item, dict):
         return pairs.combine(
             *[
-                pairs.auto_relationship(name, process(child_spec))
-                for name, child_spec in item.items()
+                auto_relationship(name, relationship_spec)
+                for name, relationship_spec in item.items()
             ]
         )
     return item
@@ -21,3 +21,7 @@ def process(spec):
 
 def alias(alias_or_aliases, item):
     return pairs.alias(alias_or_aliases, process_item(item))
+
+
+def auto_relationship(name, relationship_spec, to_attr=None):
+    return pairs.auto_relationship(name, process(relationship_spec), to_attr)

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -131,3 +131,24 @@ class SpecTestCase(TestCase):
         self.assertEqual(
             result, {"name_alias": "test owner", "widgets": [{"alias": "test widget"}]}
         )
+
+    def test_auto_relationship_function(self):
+        Widget.objects.create(
+            name="test widget", owner=Owner.objects.create(name="test owner")
+        )
+
+        prepare, project = specs.process(
+            [
+                "name",
+                specs.auto_relationship("owner", ["name"], to_attr="owner_attr"),
+            ]
+        )
+
+        queryset = prepare(Widget.objects.all())
+        instance = queryset.first()
+        result = project(instance)
+
+        self.assertEqual(
+            result,
+            {"name": "test widget", "owner_attr": {"name": "test owner"}},
+        )


### PR DESCRIPTION
This is kinda an alternative to #26 which I think is simpler and less magical.

Update: I have a "proper" solution incoming for the multiple-instances-of-the-same-relationship thing with avoids having to use `specs.auto_relationship`, but I still think exposing `specs.auto_relationship` like this is still a good idea - it makes the code clearer.

To achieve the example projection given in #26:

```
{
    "name": "django-readers for Dummies",
    "author": {"name": "Jamie"},
    "writer": {"year_of_birth": 1984},
}
```

rather than writing a spec like this:

```
spec = [
    "name",
    {"author": ["name"]},
    specs.alias("writer": {"author": ["year_of_birth"]}),
]
```

you'd have to instead write a spec like this:

```
spec = [
    "name",
    {"author": ["name"]},
    specs.auto_relationship("author", ["year_of_birth"], to_attr="writer"),
]
```

I think this is probably clearer and avoids all the weird UUID stuff.