### PR TITLE
Add or update prefetch

### DIFF
--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -55,8 +55,9 @@ doing something weird, like providing a custom queryset.
 
 def forward_relationship(name, related_queryset, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
-    prepare = qs.prefetch_forward_relationship(name, related_queryset, to_attr)
+    prepare = qs.prefetch_forward_relationship(
+        name, related_queryset, prepare_related_queryset, to_attr
+    )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 
@@ -64,17 +65,17 @@ def reverse_relationship(
     name, related_name, related_queryset, relationship_pair, to_attr=None
 ):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
     prepare = qs.prefetch_reverse_relationship(
-        name, related_name, related_queryset, to_attr
+        name, related_name, related_queryset, prepare_related_queryset, to_attr
     )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 
 def many_to_many_relationship(name, related_queryset, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
-    prepare = qs.prefetch_many_to_many_relationship(name, related_queryset, to_attr)
+    prepare = qs.prefetch_many_to_many_relationship(
+        name, related_queryset, prepare_related_queryset, to_attr
+    )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 

--- a/django_readers/qs.py
+++ b/django_readers/qs.py
@@ -104,7 +104,12 @@ def add_or_update_prefetch(
             (
                 lookup
                 for lookup in existing_lookups
-                if lookup.prefetch_through == name and lookup.to_attr == to_attr
+                if (
+                    isinstance(lookup, Prefetch)
+                    and lookup.prefetch_through == name
+                    and lookup.prefetch_to == name
+                    and lookup.to_attr == to_attr
+                )
             ),
             None,
         )

--- a/django_readers/qs.py
+++ b/django_readers/qs.py
@@ -118,8 +118,9 @@ def add_or_update_prefetch(
                 matching_lookup.queryset
             )
             return queryset.prefetch_related(*existing_lookups)
-        return queryset.prefetch_related(*existing_lookups).prefetch_related(
-            Prefetch(name, prepare_related_queryset(related_queryset), to_attr)
+        return queryset.prefetch_related(
+            Prefetch(name, prepare_related_queryset(related_queryset), to_attr),
+            *existing_lookups
         )
 
     return prefetched

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -71,7 +71,7 @@ class QuerySetTestCase(TestCase):
         )
 
         prepare = qs.prefetch_forward_relationship(
-            "owner", qs.include_fields("name")(Owner.objects.all())
+            "owner", Owner.objects.all(), qs.include_fields("name")
         )
 
         with CaptureQueriesContext(connection) as capture:
@@ -139,7 +139,7 @@ class QuerySetTestCase(TestCase):
         )
 
         prepare = qs.prefetch_forward_relationship(
-            "owner", qs.include_fields("name")(Owner.objects.all()), to_attr="attr"
+            "owner", Owner.objects.all(), qs.include_fields("name"), to_attr="attr"
         )
 
         widgets = list(prepare(Widget.objects.all()))
@@ -155,7 +155,7 @@ class QuerySetTestCase(TestCase):
         prepare = qs.pipe(
             qs.include_fields("name"),
             qs.prefetch_reverse_relationship(
-                "widget_set", "owner", qs.include_fields("name")(Widget.objects.all())
+                "widget_set", "owner", Widget.objects.all(), qs.include_fields("name")
             ),
         )
 
@@ -230,7 +230,8 @@ class QuerySetTestCase(TestCase):
             qs.prefetch_reverse_relationship(
                 "widget_set",
                 "owner",
-                qs.include_fields("name")(Widget.objects.all()),
+                Widget.objects.all(),
+                qs.include_fields("name"),
                 to_attr="attr",
             ),
         )
@@ -249,7 +250,7 @@ class QuerySetTestCase(TestCase):
         prepare = qs.pipe(
             qs.include_fields("name"),
             qs.prefetch_many_to_many_relationship(
-                "category_set", qs.include_fields("name")(Category.objects.all())
+                "category_set", Category.objects.all(), qs.include_fields("name")
             ),
         )
 
@@ -331,7 +332,8 @@ class QuerySetTestCase(TestCase):
             qs.include_fields("name"),
             qs.prefetch_many_to_many_relationship(
                 "category_set",
-                qs.include_fields("name")(Category.objects.all()),
+                Category.objects.all(),
+                qs.include_fields("name"),
                 to_attr="attr",
             ),
         )


### PR DESCRIPTION
Under normal circumstances, if you add the same prefetch to a queryset twice, Django will explode at you:

```
ValueError: '<whatever>' lookup was already seen with a different queryset. You may need to adjust the ordering of your lookups.
```

This means that it's impossible to access the same relationship twice in a spec:

```
# this doesn't work
spec = [
    "name",
    {"author": ["name"]},
    specs.alias("writer": {"author": ["year_of_birth"]}),
]
```

This PR adds a function `add_or_update_prefetch` which can be used to idempotently add prefetches. If a matching prefetch already exists on the queryset, its `.queryset` is updated using the supplied queryset function. Otherwise, a new prefetch is added.

This makes the above spec work nicely.