### PR TITLE
Add pk_list projector and pair functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Note that `django-readers` _always_ uses `prefetch_related` to load relationship
 
 Of course, it is quite possible to use `select_related` by applying `qs.select_related` at the root of your query, but this must be done manually. `django-readers` also provides `qs.select_related_fields`, which combines `select_related` with `include_fields` to allow you to specify exactly which fields you need from the related objects.
 
+You can use `pairs.pk_list` to project a list containing just the primary keys of the related objects.
+
 It is also possible to wrap a pair in `pairs.alias`, which takes the same alias argument as `projectors.alias` (see above), and applies it to the projector part of the pair:
 
 ```python

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -55,8 +55,9 @@ doing something weird, like providing a custom queryset.
 
 def forward_relationship(name, related_queryset, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
-    prepare = qs.prefetch_forward_relationship(name, related_queryset, to_attr)
+    prepare = qs.prefetch_forward_relationship(
+        name, related_queryset, prepare_related_queryset, to_attr
+    )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 
@@ -64,17 +65,17 @@ def reverse_relationship(
     name, related_name, related_queryset, relationship_pair, to_attr=None
 ):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
     prepare = qs.prefetch_reverse_relationship(
-        name, related_name, related_queryset, to_attr
+        name, related_name, related_queryset, prepare_related_queryset, to_attr
     )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 
 def many_to_many_relationship(name, related_queryset, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
-    prepare = qs.prefetch_many_to_many_relationship(name, related_queryset, to_attr)
+    prepare = qs.prefetch_many_to_many_relationship(
+        name, related_queryset, prepare_related_queryset, to_attr
+    )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -83,3 +83,10 @@ def auto_relationship(name, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
     prepare = qs.auto_prefetch_relationship(name, prepare_related_queryset, to_attr)
     return prepare, projectors.relationship(to_attr or name, project_relationship)
+
+
+def pk_list(name, to_attr=None):
+    return (
+        qs.auto_prefetch_relationship(name, qs.include_fields("pk"), to_attr=to_attr),
+        projectors.pk_list(to_attr or name),
+    )

--- a/django_readers/projectors.py
+++ b/django_readers/projectors.py
@@ -32,6 +32,16 @@ def relationship(name, related_projector):
     return wrap(name, value_getter)
 
 
+def pk_list(name):
+    """
+    Given an attribute name (which should be a relationship field), return a
+    projector which returns a list of the PK of each item in the relationship (or
+    just a single PK if this is a to-one field, but this is an inefficient way of
+    doing it).
+    """
+    return relationship(name, attrgetter("pk"))
+
+
 def combine(*projectors):
     """
     Given a list of projectors as *args, return another projector which calls each

--- a/django_readers/qs.py
+++ b/django_readers/qs.py
@@ -104,7 +104,12 @@ def add_or_update_prefetch(
             (
                 lookup
                 for lookup in existing_lookups
-                if lookup.prefetch_through == name and lookup.to_attr == to_attr
+                if (
+                    isinstance(lookup, Prefetch)
+                    and lookup.prefetch_through == name
+                    and lookup.prefetch_to == name
+                    and lookup.to_attr == to_attr
+                )
             ),
             None,
         )

--- a/django_readers/qs.py
+++ b/django_readers/qs.py
@@ -118,8 +118,9 @@ def add_or_update_prefetch(
                 matching_lookup.queryset
             )
             return queryset.prefetch_related(*existing_lookups)
-        return queryset.prefetch_related(*existing_lookups).prefetch_related(
-            Prefetch(name, prepare_related_queryset(related_queryset), to_attr)
+        return queryset.prefetch_related(
+            Prefetch(name, prepare_related_queryset(related_queryset), to_attr),
+            *existing_lookups
         )
 
     return prefetched

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -506,3 +506,29 @@ class FilterTestCase(TestCase):
         self.assertEqual(len(queryset), 1)
         result = project(queryset.first())
         self.assertEqual(result, {"name": "first"})
+
+
+class PKListTestCase(TestCase):
+    def test_pk_list(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        prepare, project = pairs.pk_list("widget_set")
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widget_set": [1, 2, 3]})
+
+    def test_pk_list_with_to_attr(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        prepare, project = pairs.pk_list("widget_set", to_attr="widgets")
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widgets": [1, 2, 3]})

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -144,3 +144,17 @@ class MethodTestCase(TestCase):
         project = projectors.method("hello", "tester")
         result = project(Widget())
         self.assertEqual(result, {"hello": "hello, tester!"})
+
+
+class PKListTestCase(TestCase):
+    def test_pk_list(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        project = projectors.pk_list("widget_set")
+
+        result = project(owner)
+
+        self.assertEqual(result, {"widget_set": [1, 2, 3]})

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -71,7 +71,7 @@ class QuerySetTestCase(TestCase):
         )
 
         prepare = qs.prefetch_forward_relationship(
-            "owner", qs.include_fields("name")(Owner.objects.all())
+            "owner", Owner.objects.all(), qs.include_fields("name")
         )
 
         with CaptureQueriesContext(connection) as capture:
@@ -139,7 +139,7 @@ class QuerySetTestCase(TestCase):
         )
 
         prepare = qs.prefetch_forward_relationship(
-            "owner", qs.include_fields("name")(Owner.objects.all()), to_attr="attr"
+            "owner", Owner.objects.all(), qs.include_fields("name"), to_attr="attr"
         )
 
         widgets = list(prepare(Widget.objects.all()))
@@ -155,7 +155,7 @@ class QuerySetTestCase(TestCase):
         prepare = qs.pipe(
             qs.include_fields("name"),
             qs.prefetch_reverse_relationship(
-                "widget_set", "owner", qs.include_fields("name")(Widget.objects.all())
+                "widget_set", "owner", Widget.objects.all(), qs.include_fields("name")
             ),
         )
 
@@ -230,7 +230,8 @@ class QuerySetTestCase(TestCase):
             qs.prefetch_reverse_relationship(
                 "widget_set",
                 "owner",
-                qs.include_fields("name")(Widget.objects.all()),
+                Widget.objects.all(),
+                qs.include_fields("name"),
                 to_attr="attr",
             ),
         )
@@ -249,7 +250,7 @@ class QuerySetTestCase(TestCase):
         prepare = qs.pipe(
             qs.include_fields("name"),
             qs.prefetch_many_to_many_relationship(
-                "category_set", qs.include_fields("name")(Category.objects.all())
+                "category_set", Category.objects.all(), qs.include_fields("name")
             ),
         )
 
@@ -331,7 +332,8 @@ class QuerySetTestCase(TestCase):
             qs.include_fields("name"),
             qs.prefetch_many_to_many_relationship(
                 "category_set",
-                qs.include_fields("name")(Category.objects.all()),
+                Category.objects.all(),
+                qs.include_fields("name"),
                 to_attr="attr",
             ),
         )


### PR DESCRIPTION
This adds a pair function `pk_list` which returns a flat list of the IDs of related objects:

```
spec = [
    "title",
    "publication_year",
    pk_list("author_set"),
]
```

results in..

```
{
    "title": "django-readers for dummies",
    "publication_year": "2021",
    "author_set": [1, 2, 3],
}
```