### PR TITLE
Add pk_list projector and pair functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Note that `django-readers` _always_ uses `prefetch_related` to load relationship
 
 Of course, it is quite possible to use `select_related` by applying `qs.select_related` at the root of your query, but this must be done manually. `django-readers` also provides `qs.select_related_fields`, which combines `select_related` with `include_fields` to allow you to specify exactly which fields you need from the related objects.
 
+You can use `pairs.pk_list` to project a list containing just the primary keys of the related objects.
+
 It is also possible to wrap a pair in `pairs.alias`, which takes the same alias argument as `projectors.alias` (see above), and applies it to the projector part of the pair:
 
 ```python

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -82,3 +82,10 @@ def auto_relationship(name, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
     prepare = qs.auto_prefetch_relationship(name, prepare_related_queryset, to_attr)
     return prepare, projectors.relationship(to_attr or name, project_relationship)
+
+
+def pk_list(name, to_attr=None):
+    return (
+        qs.auto_prefetch_relationship(name, qs.include_fields("pk"), to_attr=to_attr),
+        projectors.pk_list(to_attr or name),
+    )

--- a/django_readers/projectors.py
+++ b/django_readers/projectors.py
@@ -32,6 +32,16 @@ def relationship(name, related_projector):
     return wrap(name, value_getter)
 
 
+def pk_list(name):
+    """
+    Given an attribute name (which should be a relationship field), return a
+    projector which returns a list of the PK of each item in the relationship (or
+    just a single PK if this is a to-one field, but this is an inefficient way of
+    doing it).
+    """
+    return relationship(name, attrgetter("pk"))
+
+
 def combine(*projectors):
     """
     Given a list of projectors as *args, return another projector which calls each

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -506,3 +506,29 @@ class FilterTestCase(TestCase):
         self.assertEqual(len(queryset), 1)
         result = project(queryset.first())
         self.assertEqual(result, {"name": "first"})
+
+
+class PKListTestCase(TestCase):
+    def test_pk_list(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        prepare, project = pairs.pk_list("widget_set")
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widget_set": [1, 2, 3]})
+
+    def test_pk_list_with_to_attr(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        prepare, project = pairs.pk_list("widget_set", to_attr="widgets")
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widgets": [1, 2, 3]})

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -144,3 +144,17 @@ class MethodTestCase(TestCase):
         project = projectors.method("hello", "tester")
         result = project(Widget())
         self.assertEqual(result, {"hello": "hello, tester!"})
+
+
+class PKListTestCase(TestCase):
+    def test_pk_list(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        project = projectors.pk_list("widget_set")
+
+        result = project(owner)
+
+        self.assertEqual(result, {"widget_set": [1, 2, 3]})


### PR DESCRIPTION
Supercedes #29 (against `main`).

This adds a pair function `pk_list` which returns a flat list of the IDs of related objects:

```
spec = [
    "title",
    "publication_year",
    pk_list("author_set"),
]
```

results in..

```
{
    "title": "django-readers for dummies",
    "publication_year": "2021",
    "author_set": [1, 2, 3],
}
```