### PR TITLE
Expose prepare_related_queryset in the arguments to the various relationship functions

### DIFF
--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -55,8 +55,9 @@ doing something weird, like providing a custom queryset.
 
 def forward_relationship(name, related_queryset, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
-    prepare = qs.prefetch_forward_relationship(name, related_queryset, to_attr)
+    prepare = qs.prefetch_forward_relationship(
+        name, related_queryset, prepare_related_queryset, to_attr
+    )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 
@@ -64,17 +65,17 @@ def reverse_relationship(
     name, related_name, related_queryset, relationship_pair, to_attr=None
 ):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
     prepare = qs.prefetch_reverse_relationship(
-        name, related_name, related_queryset, to_attr
+        name, related_name, related_queryset, prepare_related_queryset, to_attr
     )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 
 def many_to_many_relationship(name, related_queryset, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
-    related_queryset = prepare_related_queryset(related_queryset)
-    prepare = qs.prefetch_many_to_many_relationship(name, related_queryset, to_attr)
+    prepare = qs.prefetch_many_to_many_relationship(
+        name, related_queryset, prepare_related_queryset, to_attr
+    )
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -71,7 +71,7 @@ class QuerySetTestCase(TestCase):
         )
 
         prepare = qs.prefetch_forward_relationship(
-            "owner", qs.include_fields("name")(Owner.objects.all())
+            "owner", Owner.objects.all(), qs.include_fields("name")
         )
 
         with CaptureQueriesContext(connection) as capture:
@@ -139,7 +139,7 @@ class QuerySetTestCase(TestCase):
         )
 
         prepare = qs.prefetch_forward_relationship(
-            "owner", qs.include_fields("name")(Owner.objects.all()), to_attr="attr"
+            "owner", Owner.objects.all(), qs.include_fields("name"), to_attr="attr"
         )
 
         widgets = list(prepare(Widget.objects.all()))
@@ -155,7 +155,7 @@ class QuerySetTestCase(TestCase):
         prepare = qs.pipe(
             qs.include_fields("name"),
             qs.prefetch_reverse_relationship(
-                "widget_set", "owner", qs.include_fields("name")(Widget.objects.all())
+                "widget_set", "owner", Widget.objects.all(), qs.include_fields("name")
             ),
         )
 
@@ -230,7 +230,8 @@ class QuerySetTestCase(TestCase):
             qs.prefetch_reverse_relationship(
                 "widget_set",
                 "owner",
-                qs.include_fields("name")(Widget.objects.all()),
+                Widget.objects.all(),
+                qs.include_fields("name"),
                 to_attr="attr",
             ),
         )
@@ -249,7 +250,7 @@ class QuerySetTestCase(TestCase):
         prepare = qs.pipe(
             qs.include_fields("name"),
             qs.prefetch_many_to_many_relationship(
-                "category_set", qs.include_fields("name")(Category.objects.all())
+                "category_set", Category.objects.all(), qs.include_fields("name")
             ),
         )
 
@@ -331,7 +332,8 @@ class QuerySetTestCase(TestCase):
             qs.include_fields("name"),
             qs.prefetch_many_to_many_relationship(
                 "category_set",
-                qs.include_fields("name")(Category.objects.all()),
+                Category.objects.all(),
+                qs.include_fields("name"),
                 to_attr="attr",
             ),
         )


### PR DESCRIPTION
This is the first commit on #28 without the rest:

> A little refactoring was required to pass prepare_related_queryset separately into the relationship functions, rather than supplying a pre-prepared queryset. But I actually like this interface better, as it matches the way auto_relationship works.

I still like this, despite #28 not being a good idea.