### PR TITLE
Handle the case where a OneToOneField is null

### DIFF
--- a/django_readers/projectors.py
+++ b/django_readers/projectors.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ObjectDoesNotExist
 from django_readers.utils import map_or_apply
 from operator import attrgetter, methodcaller
 
@@ -26,7 +27,10 @@ def relationship(name, related_projector):
     """
 
     def value_getter(instance):
-        related = attrgetter(name)(instance)
+        try:
+            related = attrgetter(name)(instance)
+        except ObjectDoesNotExist:
+            return None
         return map_or_apply(related, related_projector)
 
     return wrap(name, value_getter)

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -83,6 +83,12 @@ class RelationshipTestCase(TestCase):
         result = project(widget)
         self.assertEqual(result, {"owner": None})
 
+    def test_nullable_one_to_one(self):
+        widget = Widget.objects.create(thing=None)
+        project = projectors.relationship("thing", projectors.attr("name"))
+        result = project(widget)
+        self.assertEqual(result, {"thing": None})
+
     def test_many_relationships(self):
         group = Group.objects.create(name="test group")
         owner_1 = Owner.objects.create(name="owner 1", group=group)


### PR DESCRIPTION
If a `OneToOneField` is `null`, an `ObjectDoesNotExist` exception is raised when _accessing_ the relationship attribute. That means we have to handle this at the point where `attrgetter` is called, rather than in `map_or_apply`, where we handle all other "there is no related thing" cases (ie when a `ForeignKey` is null).