### PR TITLE
Add transform_value and transform_value_if_none arguments to projectors.attr and pairs.field

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ project = projectors.alias(
 )
 ```
 
-The `projectors.attr` function takes an optional argument `transform_value`, which is a function that receives the value of the attribute and returns a new value. This is useful if the value of the attribute needs to be converted in some way during projection. For example, imagine you have an `IntegerField` but you want the projector to return a stringified version of the integer value. In that case, you can use `projectors.attr("my_integer_field", transform_value=str)`. By default, the `transform_value` function is only called if the value to the attribute is not `None` (so if `my_integer_field` is `NULL` then `None` would be returned, rather than `"None"`. If you want the `transform_value` function to _always_ be called, use `projectors.attr("my_integer_field", transform_value=str, transform_value_if_null=True)`)
+The `projectors.attr` function takes an optional argument `transform_value`, which is a function that receives the value of the attribute and returns a new value. This is useful if the value of the attribute needs to be converted in some way during projection.
+
+For example, imagine you have an `IntegerField` but you want the projection to include a stringified version of the integer value. In that case, you can use `projectors.attr("my_integer_field", transform_value=str)`.
+
+By default, the `transform_value` function is only called if the value of the attribute is not `None` (so if the database value of `my_integer_field` is `NULL` then `None` would be returned, rather than the string `"None"`). If you want the `transform_value` function to _always_ be called, use `projectors.attr("my_integer_field", transform_value=str, transform_value_if_none=True)`.
 
 Finally, the `projectors.method` function will call the given method name on the instance, returning the result under a key matching the method name. Any extra arguments passed to `projectors.method` will be passed along to the method.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ project = projectors.alias(
 )
 ```
 
+The `projectors.attr` function takes an optional argument `transform_value`, which is a function that receives the value of the attribute and returns a new value. This is useful if the value of the attribute needs to be converted in some way during projection. For example, imagine you have an `IntegerField` but you want the projector to return a stringified version of the integer value. In that case, you can use `projectors.attr("my_integer_field", transform_value=str)`. By default, the `transform_value` function is only called if the value to the attribute is not `None` (so if `my_integer_field` is `NULL` then `None` would be returned, rather than `"None"`. If you want the `transform_value` function to _always_ be called, use `projectors.attr("my_integer_field", transform_value=str, transform_value_if_null=True)`)
+
 Finally, the `projectors.method` function will call the given method name on the instance, returning the result under a key matching the method name. Any extra arguments passed to `projectors.method` will be passed along to the method.
 
 ### `django_readers.pairs`: "reader pairs" combining `prepare` and `project`
@@ -173,6 +175,8 @@ result = project(queryset.first())
 print(project(author))
 #  {'name': 'Some Author'}
 ```
+
+The `pairs.field` function takes the same `transform_value` and `transform_value_if_none` arguments as `projectors.attr` (see above).
 
 Relationships can automatically be loaded and projected, too:
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -1,8 +1,12 @@
 from django_readers import projectors, qs
 
 
-def field(name):
-    return qs.include_fields(name), projectors.attr(name)
+def field(name, *, transform_value=None, transform_value_if_none=False):
+    return qs.include_fields(name), projectors.attr(
+        name,
+        transform_value=transform_value,
+        transform_value_if_none=transform_value_if_none,
+    )
 
 
 def combine(*pairs):

--- a/django_readers/projectors.py
+++ b/django_readers/projectors.py
@@ -10,8 +10,14 @@ def wrap(key, value_getter):
     return projector
 
 
-def attr(name):
-    return wrap(name, attrgetter(name))
+def attr(name, *, transform_value=None, transform_value_if_none=False):
+    def value_getter(instance):
+        value = attrgetter(name)(instance)
+        if transform_value and (value is not None or transform_value_if_none):
+            value = transform_value(value)
+        return value
+
+    return wrap(name, value_getter)
 
 
 def method(name, *args, **kwargs):

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,6 +13,8 @@ class Owner(models.Model):
 class Widget(models.Model):
     name = models.CharField(max_length=100)
     other = models.CharField(max_length=100)
+    count = models.SmallIntegerField(null=True)
+    other_count = models.SmallIntegerField(null=True)
     owner = models.ForeignKey(Owner, null=True, on_delete=models.SET_NULL)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -11,10 +11,8 @@ class Owner(models.Model):
 
 
 class Widget(models.Model):
-    name = models.CharField(max_length=100)
-    other = models.CharField(max_length=100)
-    count = models.SmallIntegerField(null=True)
-    other_count = models.SmallIntegerField(null=True)
+    name = models.CharField(max_length=100, null=True)
+    other = models.CharField(max_length=100, null=True)
     owner = models.ForeignKey(Owner, null=True, on_delete=models.SET_NULL)
 
 

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -25,6 +25,28 @@ class PairsTestCase(TestCase):
             ],
         )
 
+    def test_transform_value(self):
+        Widget.objects.create(count=5, other_count=10)
+        Widget.objects.create(count=None, other_count=None)
+
+        prepare, project = pairs.combine(
+            pairs.field("count", transform_value=str),
+            pairs.field(
+                "other_count", transform_value=str, transform_value_if_none=True
+            ),
+        )
+
+        queryset = prepare(Widget.objects.all())
+        result = [project(instance) for instance in queryset]
+
+        self.assertEqual(
+            result,
+            [
+                {"count": "5", "other_count": "10"},
+                {"count": None, "other_count": "None"},
+            ],
+        )
+
     def test_forward_many_to_one_relationship(self):
         group = Group.objects.create(name="test group")
         owner = Owner.objects.create(name="test owner", group=group)

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django_readers import pairs, projectors, qs
 from tests.models import Category, Group, Owner, Thing, Widget
+from tests.test_projectors import title_and_reverse
 
 
 class PairsTestCase(TestCase):
@@ -26,13 +27,13 @@ class PairsTestCase(TestCase):
         )
 
     def test_transform_value(self):
-        Widget.objects.create(count=5, other_count=10)
-        Widget.objects.create(count=None, other_count=None)
+        Widget.objects.create(name="test", other="other")
+        Widget.objects.create(name=None, other=None)
 
         prepare, project = pairs.combine(
-            pairs.field("count", transform_value=str),
+            pairs.field("name", transform_value=title_and_reverse),
             pairs.field(
-                "other_count", transform_value=str, transform_value_if_none=True
+                "other", transform_value=title_and_reverse, transform_value_if_none=True
             ),
         )
 
@@ -42,8 +43,8 @@ class PairsTestCase(TestCase):
         self.assertEqual(
             result,
             [
-                {"count": "5", "other_count": "10"},
-                {"count": None, "other_count": "None"},
+                {"name": "tseT", "other": "rehtO"},
+                {"name": None, "other": "enoN"},
             ],
         )
 

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -10,6 +10,29 @@ class ProjectorTestCase(TestCase):
         result = project(widget)
         self.assertEqual(result, {"name": "test"})
 
+    def test_attr_transform_value(self):
+        widget = Widget(name="test")
+        project = projectors.attr("name", transform_value=lambda value: value.upper())
+        result = project(widget)
+        self.assertEqual(result, {"name": "TEST"})
+
+    def test_attr_transform_value_if_none(self):
+        widget = Widget(name=None)
+        project = projectors.attr("name", transform_value=lambda value: value.upper())
+        result = project(widget)
+        self.assertEqual(result, {"name": None})
+
+        project = projectors.attr(
+            "name",
+            transform_value=lambda value: value.upper(),
+            transform_value_if_none=True,
+        )
+
+        with self.assertRaisesMessage(
+            AttributeError, "'NoneType' object has no attribute 'upper'"
+        ):
+            result = project(widget)
+
     def test_combine(self):
         widget = Widget.objects.create(name="test", other="other")
         project = projectors.combine(

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -3,6 +3,10 @@ from django_readers import projectors
 from tests.models import Group, Owner, Widget
 
 
+def title_and_reverse(arg):
+    return str(arg).title()[::-1]
+
+
 class ProjectorTestCase(TestCase):
     def test_attr(self):
         widget = Widget.objects.create(name="test")
@@ -12,13 +16,13 @@ class ProjectorTestCase(TestCase):
 
     def test_attr_transform_value(self):
         widget = Widget(name="test")
-        project = projectors.attr("name", transform_value=lambda value: value.upper())
+        project = projectors.attr("name", transform_value=title_and_reverse)
         result = project(widget)
-        self.assertEqual(result, {"name": "TEST"})
+        self.assertEqual(result, {"name": "tseT"})
 
     def test_attr_transform_value_if_none(self):
         widget = Widget(name=None)
-        project = projectors.attr("name", transform_value=lambda value: value.upper())
+        project = projectors.attr("name", transform_value=title_and_reverse)
         result = project(widget)
         self.assertEqual(result, {"name": None})
 


### PR DESCRIPTION
As part of experimentally upgrading existing projects to use `django-readers` (via https://github.com/dabapps/django-rest-framework-serialization-spec/pull/68) some common patterns were discovered that required more code than should be necessary. This PR attempts to implement the neatest solution I could think of to cover several of these patterns.

As an example, one project uses [django-phonenumber-field](https://github.com/stefanfoulis/django-phonenumber-field/) to store phone numbers. When serializing the custom `PhoneNumberField`, `str` must be called on the value returned by the attribute before it is passed to the renderer. To achieve this prior to this PR, you would need to do something like the following:

```python
(
    qs.include_fields("phone_number"),
    lambda instance: {
        "phone_number": str(instance.phone_number) if instance.phone_number else None
    },
)
```

With this PR, you could instead do this:

```python
pairs.field("phone_number", transform_value=str)
```

`transform_value` is a function that takes the value retrieved from the given attribute of the instance, and returns a new value that will replace it in the projection.

Note that again we are preferring explicitness over implicitness here - we're not attempting to automatically work out from the field type whether stringification is necessary, because down that route edge-case madness would lie. We're also deliberately _not_ introducing a `get_value` argument (ie a function that would be used in place of `attrgetter` to actually get the value of the attribute) because `projectors.attr` is explicitly intended to get the named attribute off the instance, and `pairs.field` is explicitly intended to include a field in the query and then return its value. `transform_value` is intended for simple use cases: it is still recommended to write a custom projector if any further customisation is needed.