### PR TITLE
Rename auto_relationship to relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Relationships can automatically be loaded and projected, too:
 prepare, project = pairs.combine(
     pairs.field("name"),
     age_pair,
-    pairs.auto_relationship("book_set", pairs.combine(
+    pairs.relationship("book_set", pairs.combine(
         pairs.field("title"),
         pairs.field("publication_year"),
     ))
@@ -209,7 +209,7 @@ As a shortcut, the `pairs` module provides a function called `filter`, which can
 prepare, project = pairs.combine(
     pairs.field("name"),
     age_pair,
-    pairs.auto_relationship(
+    pairs.relationship(
         "book_set",
         pairs.combine(
             pairs.filter(publication_year__gte=2020),
@@ -236,7 +236,7 @@ The resulting nested dictionary structure may be returned from as view as a JSON
 A spec is a list. Under the hood, the `specs` module is a very lightweight wrapper on top of `pairs` - it applies simple transformations to the items in the list to replace them with the relevant pair functions. The list may contain:
 
 * _strings_, which are interpreted as field names and are replaced with `pairs.field`,
-* _dictionaries_, which are interpreted as relationships (with the keys specifying the relationship name and the values being specs for projecting the related objects) and are replaced with `pairs.auto_relationship`.
+* _dictionaries_, which are interpreted as relationships (with the keys specifying the relationship name and the values being specs for projecting the related objects) and are replaced with `pairs.relationship`.
 * _pairs_ of `(prepare, project)` functions (see previous section), which are left as-is.
 
 The example from the last section may be written as the following spec:

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -47,7 +47,7 @@ Below are pair functions which return the various queryset functions that prefet
 relationships of various types, and then project those related objects.
 
 There are functions for forward, reverse or many-to-many relationships, and then
-an `auto_relationship` function which selects the correct one by introspecting the
+a `relationship` function which selects the correct one by introspecting the
 model. It shouldn't usually be necessary to use the manual functions unless you're
 doing something weird, like providing a custom queryset.
 """
@@ -79,7 +79,7 @@ def many_to_many_relationship(name, related_queryset, relationship_pair, to_attr
     return prepare, projectors.relationship(to_attr or name, project_relationship)
 
 
-def auto_relationship(name, relationship_pair, to_attr=None):
+def relationship(name, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
     prepare = qs.auto_prefetch_relationship(name, prepare_related_queryset, to_attr)
     return prepare, projectors.relationship(to_attr or name, project_relationship)

--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -8,7 +8,7 @@ def process_item(item):
     if isinstance(item, dict):
         return pairs.combine(
             *[
-                auto_relationship(name, relationship_spec)
+                relationship(name, relationship_spec)
                 for name, relationship_spec in item.items()
             ]
         )
@@ -23,5 +23,5 @@ def alias(alias_or_aliases, item):
     return pairs.alias(alias_or_aliases, process_item(item))
 
 
-def auto_relationship(name, relationship_spec, to_attr=None):
-    return pairs.auto_relationship(name, process(relationship_spec), to_attr)
+def relationship(name, relationship_spec, to_attr=None):
+    return pairs.relationship(name, process(relationship_spec), to_attr)

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -331,7 +331,7 @@ class PairsTestCase(TestCase):
             },
         )
 
-    def test_auto_relationship(self):
+    def test_relationship(self):
         owner = Owner.objects.create(name="test owner")
         widget = Widget.objects.create(name="test widget", owner=owner)
         category = Category.objects.create(name="test category")
@@ -340,28 +340,28 @@ class PairsTestCase(TestCase):
 
         prepare, project = pairs.combine(
             pairs.field("name"),
-            pairs.auto_relationship(
+            pairs.relationship(
                 "owner",
                 pairs.combine(
                     pairs.field("name"),
-                    pairs.auto_relationship(
+                    pairs.relationship(
                         "widget_set",
                         pairs.field("name"),
                     ),
                 ),
             ),
-            pairs.auto_relationship(
+            pairs.relationship(
                 "category_set",
                 pairs.combine(
                     pairs.field("name"),
-                    pairs.auto_relationship("widget_set", pairs.field("name")),
+                    pairs.relationship("widget_set", pairs.field("name")),
                 ),
             ),
-            pairs.auto_relationship(
+            pairs.relationship(
                 "thing",
                 pairs.combine(
                     pairs.field("name"),
-                    pairs.auto_relationship("widget", pairs.field("name")),
+                    pairs.relationship("widget", pairs.field("name")),
                 ),
             ),
         )
@@ -390,14 +390,14 @@ class PairsTestCase(TestCase):
             },
         )
 
-    def test_auto_relationship_with_to_attr(self):
+    def test_relationship_with_to_attr(self):
         Widget.objects.create(
             name="test widget", owner=Owner.objects.create(name="test owner")
         )
 
         prepare, project = pairs.combine(
             pairs.field("name"),
-            pairs.auto_relationship(
+            pairs.relationship(
                 "owner",
                 pairs.field("name"),
                 to_attr="owner_attr",
@@ -425,7 +425,7 @@ class PairsTestCase(TestCase):
             pairs.alias("name_alias", pairs.field("name")),
             pairs.alias(
                 {"widget_set": "widgets"},
-                pairs.auto_relationship(
+                pairs.relationship(
                     "widget_set",
                     pairs.alias({"name": "alias"}, pairs.field("name")),
                 ),

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -132,7 +132,7 @@ class SpecTestCase(TestCase):
             result, {"name_alias": "test owner", "widgets": [{"alias": "test widget"}]}
         )
 
-    def test_auto_relationship_function(self):
+    def test_relationship_function(self):
         Widget.objects.create(
             name="test widget", owner=Owner.objects.create(name="test owner")
         )
@@ -140,7 +140,7 @@ class SpecTestCase(TestCase):
         prepare, project = specs.process(
             [
                 "name",
-                specs.auto_relationship("owner", ["name"], to_attr="owner_attr"),
+                specs.relationship("owner", ["name"], to_attr="owner_attr"),
             ]
         )
 


### PR DESCRIPTION
This is obviously a backwards-incompatible breaking change, but we're pre-1.0 so I'm ok with that.

I think `relationship` is a better name and `auto_` is superfluous. It mirrors the other main pair function, `field`, better (it was never "`auto_field`") and is more succinct.

Note I've left the underlying queryset function `auto_prefetch_relationship` alone, as I think at that low level it is important that the name explains clearly what's going on.