### PR TITLE
Add pair shortcut functions for exclude and order_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ prepare, project = pairs.alias(
 )
 ```
 
-As a shortcut, the `pairs` module providess function called `filter`, `exclude` and `order_by`, which can be used to apply the given queryset functions to the queryset without affecting the projection. These are equivalent to (for example) `(qs.filter(arg=value), projectors.noop)` and are most useful for filtering or ordering related objects:
+As a shortcut, the `pairs` module provides functions called `filter`, `exclude` and `order_by`, which can be used to apply the given queryset functions to the queryset without affecting the projection. These are equivalent to (for example) `(qs.filter(arg=value), projectors.noop)` and are most useful for filtering or ordering related objects:
 
 ```python
 prepare, project = pairs.combine(

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ prepare, project = pairs.alias(
 )
 ```
 
-As a shortcut, the `pairs` module provides a function called `filter`, which can be used to apply a filter to the queryset without affecting the projection. This is equivalent to `(qs.filter(arg=value), projectors.noop)` and is most useful for filtering related objects:
+As a shortcut, the `pairs` module providess function called `filter`, `exclude` and `order_by`, which can be used to apply the given queryset functions to the queryset without affecting the projection. These are equivalent to (for example) `(qs.filter(arg=value), projectors.noop)` and are most useful for filtering or ordering related objects:
 
 ```python
 prepare, project = pairs.combine(
@@ -213,6 +213,7 @@ prepare, project = pairs.combine(
         "book_set",
         pairs.combine(
             pairs.filter(publication_year__gte=2020),
+            pairs.order_by("title"),
             pairs.field("title"),
             pairs.field("publication_year"),
         ),

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -42,6 +42,14 @@ def filter(*args, **kwargs):
     return prepare_only(qs.filter(*args, **kwargs))
 
 
+def exclude(*args, **kwargs):
+    return prepare_only(qs.exclude(*args, **kwargs))
+
+
+def order_by(*args, **kwargs):
+    return prepare_only(qs.order_by(*args, **kwargs))
+
+
 """
 Below are pair functions which return the various queryset functions that prefetch
 relationships of various types, and then project those related objects.

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -508,6 +508,38 @@ class FilterTestCase(TestCase):
         self.assertEqual(result, {"name": "first"})
 
 
+class ExcludeTestCase(TestCase):
+    def test_exclude(self):
+        Widget.objects.create(name="first")
+        Widget.objects.create(name="second")
+
+        prepare, project = pairs.combine(
+            pairs.exclude(name="first"),
+            pairs.field("name"),
+        )
+
+        queryset = prepare(Widget.objects.all())
+        self.assertEqual(len(queryset), 1)
+        result = project(queryset.first())
+        self.assertEqual(result, {"name": "second"})
+
+
+class OrderByTestCase(TestCase):
+    def test_order_by(self):
+        Widget.objects.create(name="c")
+        Widget.objects.create(name="b")
+        Widget.objects.create(name="a")
+
+        prepare, project = pairs.combine(
+            pairs.order_by("name"),
+            pairs.field("name"),
+        )
+
+        queryset = prepare(Widget.objects.all())
+        result = [project(item) for item in queryset]
+        self.assertEqual(result, [{"name": "a"}, {"name": "b"}, {"name": "c"}])
+
+
 class PKListTestCase(TestCase):
     def test_pk_list(self):
         owner = Owner.objects.create(name="test owner")


### PR DESCRIPTION
In addition to the existing `pairs.filter`, this PR adds `pairs.exclude` and `pairs.order_by`. I think these three should cover 99% of use cases (ie filtering/ordering related objects).

Of course, any queryset function can be applied in this way by adding `pairs.prepare_only(some_queryset_function)` to your spec.