### PR TITLE
Improve select_related support

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Note that `django-readers` _always_ uses `prefetch_related` to load relationship
 
 Of course, it is quite possible to use `select_related` by applying `qs.select_related` at the root of your query, but this must be done manually. `django-readers` also provides `qs.select_related_fields`, which combines `select_related` with `include_fields` to allow you to specify exactly which fields you need from the related objects.
 
+There is also a pair function, `pairs.select_related_fields`, which combines this queryset function with a tree of projectors to project the related objects. Note that this only works for projecting simple fields on the related models. If you need to customise the projection you should use a pair consisting of `qs.select_related_fields` and your own hand-written projector.
+
 You can use `pairs.pk_list` to project a list containing just the primary keys of the related objects.
 
 It is also possible to wrap a pair in `pairs.alias`, which takes the same alias argument as `projectors.alias` (see above), and applies it to the projector part of the pair:

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,6 +14,9 @@ class Widget(models.Model):
     name = models.CharField(max_length=100, null=True)
     other = models.CharField(max_length=100, null=True)
     owner = models.ForeignKey(Owner, null=True, on_delete=models.SET_NULL)
+    other_owner = models.ForeignKey(
+        Owner, null=True, on_delete=models.SET_NULL, related_name="+"
+    )
 
 
 class Thing(models.Model):

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -587,3 +587,28 @@ class PKListTestCase(TestCase):
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
         self.assertEqual(result, {"widgets": [1, 2, 3]})
+
+
+class SelectRelatedFieldsTestCase(TestCase):
+    def test_select_related_fields(self):
+        group = Group.objects.create(name="test group")
+        owner = Owner.objects.create(name="test owner", group=group)
+        other_owner = Owner.objects.create(name="other owner", group=group)
+        Widget.objects.create(name="test widget", owner=owner, other_owner=other_owner)
+
+        prepare, project = pairs.select_related_fields(
+            "owner__name",
+            "other_owner__name",
+            "owner__group__name",
+            "other_owner__group__name",
+        )
+
+        queryset = prepare(Widget.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(
+            result,
+            {
+                "owner": {"name": "test owner", "group": {"name": "test group"}},
+                "other_owner": {"name": "other owner", "group": {"name": "test group"}},
+            },
+        )


### PR DESCRIPTION
This adds a new pair function, `select_related_fields`, which is used to prepare and project relationships via database joins rather than in-Python `prefetch_related`. It can be used like this:

```python
pairs.select_related_fields(
    "related_thing__some_field",
    "related_thing__other_field",
    "related_thing__third_field",
)
```

This would result in:

```json
{
  "related_thing": {
    "some_field": "some value",
    "other_field": "other value",
    "third_field": "third value",
  }
}
```

This also works as you'd expect with more deeply nested relationships.

Note that due to the `select_related` works, this is quite restricted compared to the way "standard" prefetched relationships work. Because there's no queryset for the related objects, we can't prepare it, so we can't use any of the normal mechanism for dealing with relationships. Also, the projection only works with basic fields (and other related objects), so there's no way to customise the projection. If you did need to do that, you'd have to drop down to using a pair consisting of `qs.select_related_fields` and a custom projector.