### PR TITLE
Count and exists pair functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ prepare, project = pairs.combine(
 
 The `pairs.field_display` function takes the field name as its single argument and returns a pair which loads the field from the database, and then projects the result of calling `get_<field>_display` under the key `<field>_display`.
 
+Finally, `pairs.count` and `pairs.exists` provide shortcuts to annotate a queryset with the count or existence of related objects, and project these values under the keys `<relationship_name>_count` and `<relationship_name>_exists` respectively.
+
 ### `django_readers.specs`: a high-level specification for efficient data querying and projection
 
 This layer is the real magic of `django-readers`: a straightforward way of specifying the shape of your data in order to efficiently select and project a complex tree of related objects.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ prepare, project = pairs.combine(
 
 The `pairs.field_display` function takes the field name as its single argument and returns a pair which loads the field from the database, and then projects the result of calling `get_<field>_display` under the key `<field>_display`.
 
-Finally, `pairs.count` and `pairs.exists` provide shortcuts to annotate a queryset with the count or existence of related objects, and project these values under the keys `<relationship_name>_count` and `<relationship_name>_exists` respectively.
+Finally, `pairs.count` and `pairs.has` provide shortcuts to annotate a queryset with the count or existence of related objects, and project these values under the keys `<relationship_name>_count` and `has_<relationship_name>` respectively.
 
 ### `django_readers.specs`: a high-level specification for efficient data querying and projection
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django_readers import projectors, qs
 
 
@@ -39,6 +40,14 @@ def field_display(name):
     """
     return qs.include_fields(name), projectors.alias(
         f"{name}_display", projectors.method(f"get_{name}_display")
+    )
+
+
+def count(name, distinct=True):
+    attr_name = f"{name}_count"
+    return (
+        qs.annotate(**{attr_name: Count(name, distinct=distinct)}),
+        projectors.attr(attr_name),
     )
 
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -51,6 +51,16 @@ def count(name, distinct=True):
     )
 
 
+def exists(name, distinct=True):
+    attr_name = f"{name}_count"
+    return (
+        qs.annotate(**{attr_name: Count(name, distinct=distinct)}),
+        projectors.alias(
+            f"{name}_exists", projectors.attr(attr_name, transform_value=bool)
+        ),
+    )
+
+
 def filter(*args, **kwargs):
     return prepare_only(qs.filter(*args, **kwargs))
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -51,12 +51,12 @@ def count(name, distinct=True):
     )
 
 
-def exists(name, distinct=True):
+def has(name, distinct=True):
     attr_name = f"{name}_count"
     return (
         qs.annotate(**{attr_name: Count(name, distinct=distinct)}),
         projectors.alias(
-            f"{name}_exists", projectors.attr(attr_name, transform_value=bool)
+            f"has_{name}", projectors.attr(attr_name, transform_value=bool)
         ),
     )
 

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -603,22 +603,22 @@ class CountTestCase(TestCase):
         self.assertEqual(result, {"widget_count": 3})
 
 
-class ExistsTestCase(TestCase):
-    def test_exists_false(self):
+class HasTestCase(TestCase):
+    def test_has_false(self):
         Owner.objects.create(name="test owner")
 
-        prepare, project = pairs.exists("widget")
+        prepare, project = pairs.has("widget")
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
-        self.assertEqual(result, {"widget_exists": False})
+        self.assertEqual(result, {"has_widget": False})
 
-    def test_exists_true(self):
+    def test_has_true(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test", owner=owner)
 
-        prepare, project = pairs.exists("widget")
+        prepare, project = pairs.has("widget")
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
-        self.assertEqual(result, {"widget_exists": True})
+        self.assertEqual(result, {"has_widget": True})

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -601,3 +601,24 @@ class CountTestCase(TestCase):
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
         self.assertEqual(result, {"widget_count": 3})
+
+
+class ExistsTestCase(TestCase):
+    def test_exists_false(self):
+        Owner.objects.create(name="test owner")
+
+        prepare, project = pairs.exists("widget")
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widget_exists": False})
+
+    def test_exists_true(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test", owner=owner)
+
+        prepare, project = pairs.exists("widget")
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widget_exists": True})

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -587,3 +587,17 @@ class PKListTestCase(TestCase):
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
         self.assertEqual(result, {"widgets": [1, 2, 3]})
+
+
+class CountTestCase(TestCase):
+    def test_count(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        prepare, project = pairs.count("widget")
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widget_count": 3})


### PR DESCRIPTION
As discussed in https://github.com/dabapps/django-rest-framework-serialization-spec/pull/68#issuecomment-836290871, this adds `pairs.count` and `pairs.has`.