### PR TITLE
Add Django REST framework SpecMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,30 @@ prepare, project = specs.process(
 )
 ```
 
+### `django-rest-framework` view mixin
+
+If you use [django-rest-framework](https://www.django-rest-framework.org/), `django-readers` provides a shortcut that allows you to easily use a `spec` to serialize your data:
+
+```python
+from django_readers.rest_framework import SpecMixin
+
+class AuthorDetailView(SpecMixin, RetrieveAPIView):
+    queryset = Author.objects.all()
+    spec = [
+        "id",
+        "name",
+        {"book_set": [
+            "id",
+            "title",
+            "publication_year",
+        ]},
+    ]
+```
+
+This mixin is only suitable for use with `RetrieveAPIView` or `ListAPIView`. It doesn't use a "real" Serializer: it calls the `project` function that is the result of processing your `spec`. We recommend using separate views for endpoints that modify data, rather than combining these concerns into a single endpoint.
+
+If your endpoint needs to provide dynamic behaviour based on the user making the request, you should instead override the `get_spec` method and return your spec.
+
 ### A note on `django-zen-queries`
 
 An important pattern to avoid inefficient database queries in Django projects is to isolate the *fetching of data* from the *rendering of data*. This pattern can be implemented with the help of [`django-zen-queries`](https://github.com/dabapps/django-zen-queries), which allows you to mark blocks of code under which database queries are not allowed.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 black==20.8b1
 flake8==3.8.4
 isort==5.7.0
+djangorestframework==3.12.4

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -1,0 +1,49 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import cached_property
+from django_readers import specs
+
+
+class ProjectionSerializer:
+    def __init__(self, data=None, many=False, context=None):
+        self.many = many
+        self._data = data
+        self.context = context
+
+    @property
+    def data(self):
+        project = self.context["view"].project
+        if self.many:
+            return [project(item) for item in self._data]
+        return project(self._data)
+
+
+class SpecMixin:
+
+    spec = None
+
+    def get_spec(self):
+        if self.spec is None:
+            raise ImproperlyConfigured("SpecMixin requires spec or get_spec")
+        return self.spec
+
+    def get_reader_pair(self):
+        return specs.process(self.get_spec())
+
+    @cached_property
+    def reader_pair(self):
+        return self.get_reader_pair()
+
+    @property
+    def prepare(self):
+        return self.reader_pair[0]
+
+    @property
+    def project(self):
+        return self.reader_pair[1]
+
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        return self.prepare(queryset)
+
+    def get_serializer_class(self):
+        return ProjectionSerializer

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -18,7 +18,6 @@ class ProjectionSerializer:
 
 
 class SpecMixin:
-
     spec = None
 
     def get_spec(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,11 @@
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
-INSTALLED_APPS = ["tests"]
+INSTALLED_APPS = [
+    "tests",
+    "rest_framework",
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+]
 
 SECRET_KEY = "abcde12345"
 

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,0 +1,99 @@
+from django.test import TestCase
+from django_readers.rest_framework import SpecMixin
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.test import APIRequestFactory
+from tests.models import Category, Group, Owner, Widget
+
+
+class WidgetListView(SpecMixin, ListAPIView):
+    queryset = Widget.objects.all()
+    spec = [
+        "name",
+        {
+            "owner": [
+                "name",
+                {
+                    "group": [
+                        "name",
+                    ]
+                },
+            ]
+        },
+    ]
+
+
+class CategoryDetailView(SpecMixin, RetrieveAPIView):
+    queryset = Category.objects.all()
+    spec = [
+        "name",
+        {
+            "widget_set": [
+                "name",
+                {
+                    "owner": [
+                        "name",
+                    ]
+                },
+            ]
+        },
+    ]
+
+
+class RESTFrameworkTestCase(TestCase):
+    def test_list(self):
+        Widget.objects.create(
+            name="test widget",
+            owner=Owner.objects.create(
+                name="test owner", group=Group.objects.create(name="test group")
+            ),
+        )
+
+        request = APIRequestFactory().get("/")
+        view = WidgetListView.as_view()
+
+        with self.assertNumQueries(3):
+            response = view(request)
+
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "name": "test widget",
+                    "owner": {
+                        "name": "test owner",
+                        "group": {
+                            "name": "test group",
+                        },
+                    },
+                }
+            ],
+        )
+
+    def test_detail(self):
+        category = Category.objects.create(name="test category")
+        owner = Owner.objects.create(name="test owner")
+        category.widget_set.add(Widget.objects.create(name="test 1", owner=owner))
+        category.widget_set.add(Widget.objects.create(name="test 2", owner=owner))
+
+        request = APIRequestFactory().get("/")
+        view = CategoryDetailView.as_view()
+
+        with self.assertNumQueries(3):
+            response = view(request, pk=str(category.pk))
+
+        self.assertEqual(
+            response.data,
+            {
+                "name": "test category",
+                "widget_set": [
+                    {
+                        "name": "test 1",
+                        "owner": {"name": "test owner"},
+                    },
+                    {
+                        "name": "test 2",
+                        "owner": {"name": "test owner"},
+                    },
+                ],
+            },
+        )


### PR DESCRIPTION
This adds direct support for Django REST framework into `django-readers` via a `SpecMixin` class that can be used something like this:

```python
class AuthorDetailView(SpecMixin, RetrieveAPIView):
    queryset = Author.objects.all()
    spec = [
        "id",
        "name",
        {"book_set": [
            "id",
            "title",
            "publication_year",
        ]},
    ]
```

The implementation is a stripped-down, simplified version of the `SerializationSpecMixin` from [this PR](https://github.com/dabapps/django-rest-framework-serialization-spec/pull/68), but with the preprocessing step (which supports SSM's "plugin" concept) removed. The `spec` is just a standard `django-readers` spec.

This PR is really just to gauge opinion on whether this is a good idea. My original plan for `django-readers` was to leave all of this high-level view stuff out: to provide just a set of low-level tools that could be _used_ in views. SSM was going to be the higher-level library that allowed users to easily serialize data based on a spec.

However, since working on a the SSM upgrade branch I do see the utility and appeal of a mixin like this. It's less than 50 lines of code, and being able to create detail and list endpoints so concisely is really compelling.

This would, however, kinda make SSM redundant. It _could_ live on as a project which extends `django-readers` with the "plugin" concept, but I'm not sure that's really a good idea when reader pairs can do all the same things as plugins.

Anyway, opinions welcomed.

Also this PR needs docs.