### PR TITLE
Support None-safe navigation in attr projector

### DIFF
--- a/django_readers/projectors.py
+++ b/django_readers/projectors.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
-from django_readers.utils import map_or_apply
+from django_readers.utils import map_or_apply, none_safe_attrgetter
 from operator import attrgetter, methodcaller
 
 
@@ -12,7 +12,7 @@ def wrap(key, value_getter):
 
 def attr(name, *, transform_value=None, transform_value_if_none=False):
     def value_getter(instance):
-        value = attrgetter(name)(instance)
+        value = none_safe_attrgetter(name)(instance)
         if transform_value and (value is not None or transform_value_if_none):
             value = transform_value(value)
         return value
@@ -34,7 +34,7 @@ def relationship(name, related_projector):
 
     def value_getter(instance):
         try:
-            related = attrgetter(name)(instance)
+            related = none_safe_attrgetter(name)(instance)
         except ObjectDoesNotExist:
             return None
         return map_or_apply(related, related_projector)

--- a/django_readers/utils.py
+++ b/django_readers/utils.py
@@ -26,6 +26,24 @@ def map_or_apply(obj, fn):
             return fn(obj)
 
 
+def none_safe_attrgetter(attr):
+    """
+    Like operator.attrgetter, but if using a dotted-path style, and any of the
+    attributes in the path has a value of None, the whole function short-circuits and
+    returns None rather than raising AttributeError when the next part of the dotted
+    path tries to grab an attribute off a None.
+    """
+
+    def none_safe_get_attr(obj):
+        for name in attr.split("."):
+            obj = getattr(obj, name)
+            if obj is None:
+                return None
+        return obj
+
+    return none_safe_get_attr
+
+
 def queries_disabled(pair):
     prepare, project = pair
     decorator = zen_queries.queries_disabled() if zen_queries else lambda fn: fn

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -74,6 +74,12 @@ class ProjectorTestCase(TestCase):
         with self.assertRaises(TypeError):
             project(widget)
 
+    def test_dotted_attr_handles_none(self):
+        widget = Widget.objects.create(name="test")
+        project = projectors.attr("owner.name")
+        result = project(widget)
+        self.assertEqual(result, {"owner.name": None})
+
 
 class RelationshipTestCase(TestCase):
     def test_relationship_projector(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,3 +24,16 @@ class MapOrApplyTestCase(TestCase):
         Widget.objects.create(name="test 2")
         result = utils.map_or_apply(Widget.objects, lambda item: item.name)
         self.assertEqual(result, ["test 1", "test 2"])
+
+
+class NoneSafeAttrGetterTestCase(TestCase):
+    def test_does_not_raise_error_when_attr_is_none(self):
+        widget = Widget()
+        get_attr = utils.none_safe_attrgetter("owner.name")
+        self.assertIsNone(get_attr(widget))
+
+    def test_does_raise_error_when_attr_missing(self):
+        widget = Widget()
+        get_attr = utils.none_safe_attrgetter("chowner.chame")
+        with self.assertRaises(AttributeError):
+            get_attr(widget)


### PR DESCRIPTION
Given the following:

```
class Owner(models.Model):
    name = models.CharField(max_length=100)

class Widget(models.Model):
    owner = models.ForeignKey(Owner, null=True, on_delete=models.SET_NULL)

widget = Widget.objects.create(owner=None)
```

Previously, using a dotted path in the `attr` projector like this:

```
project = projectors.attr("owner.name")
project(widget)
```

would blow up with `AttributeError`. Now, it fails nicely by short-circuiting and just returning `{"owner.name": None}`.