### PR TITLE
Introduce the concept of "producers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Install from PyPI
 `django-readers` is a library to help with organising business logic in a Django codebase, following a function-oriented style. It allows you to concisely specify data dependencies in your views and attempts to extract and transform that data as efficiently as possible, eliminating the [N+1 queries problem](https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem-in-orm-object-relational-mapping). It introduces a few simple concepts, and provides some tools to assemble them together into a working application. It can easily be combined with existing patterns and libraries.
 
 * **queryset preparation functions** replace custom queryset methods and encapsulate data selection: filtering, annotation etc. They can be composed to express complex selection logic.
-* **projector functions** replace model methods and encapsulate business logic for transforming and presenting data. They can be combined to form lightweight business objects (dictionaries) that are the right shape for the code that consumes them.
-* **reader pairs** combine queryset functions and projectors, expressing the dependencies between them.
+* **producer functions** replace model methods and encapsulate business logic for transforming and presenting data. They can be combined to form lightweight business objects (dictionaries) that are the right shape for the code that consumes them.
+* **reader pairs** combine queryset functions and producers, expressing the dependencies between them.
 * a high-level **spec** provides a concise way to express exactly which data should be selected and projected at the point of use.
 
 ## A note on this documentation
@@ -47,7 +47,7 @@ The functionality that `django-readers` provides is deliberately straightforward
 
 ## Features and concepts
 
-`django-readers` is organised in three layers of _"reader functions"_. At the highest level of abstraction is `django_readers.specs` (the top layer), which depends on `django_readers.pairs` (the middle layer), which depends on `django_readers.projectors` and `django_readers.qs` (the bottom layer).
+`django-readers` is organised in three layers of _"reader functions"_. At the highest level of abstraction is `django_readers.specs` (the top layer), which depends on `django_readers.pairs` (the middle layer), which depends on `django_readers.producers`, `django_readers.projectors` and `django_readers.qs` (the bottom layer).
 
 These layers can be intermingled in a real-world application. To expain each layer, it makes most sense to start at the bottom and work upwards.
 
@@ -78,43 +78,58 @@ recent_books_with_prefetched_authors = qs.pipe(
 queryset = recent_books_with_prefetched_authors(Book.objects.all())
 ```
 
-### `django_readers.projectors`: model projection functions
+### `django_readers.producers` and `django_readers.projectors`: value production and model projection functions
 
-A projector is a function that accepts a model instance as its single argument, and returns a dictionary containing some subset or transformation of the instance data.
+A producer is a function that accepts a model instance as its single argument, and returns a value representing a subset or transformation of the instance data.
 
-These functions "project" your data layer into your application's business logic domain. Business logic that would traditionally go in model methods should instead go in projectors.
-
-Think of the dictionary returned by a projector (the "projection") as the simplest possible domain object. In most cases, it makes sense for an individual projector function to return a dictionary containing just a single key and value.
+Business logic that would traditionally go in model methods should instead go in producers.
 
 ```python
 from datetime import datetime
 
-def project_age(instance):
-    return {"age": datetime.now().year - instance.birth_year}
+def produce_age(instance):
+    return datetime.now().year - instance.birth_year
+
+author = Author(name="Some Author", birth_year=1984)
+print(produce_age(author))
+#  37
+```
+
+The simplest producer is one that returns the value of an object attribute. `django-readers` provides a producer that does this:
+
+```python
+from django_readers import producers
+
+author = Author(name="Some Author")
+produce_name = producers.attr("name")
+print(produce_name(author))
+#  'Some Author'
+```
+
+Producers return a value, but in order to convert a model instance into a lightweight business object suitable for passing around your project, this value must be combined with a name. This is the role of a projector. A projector function takes a model instance and returns a dictionary mapping keys to the values returned by producer functions.
+
+These functions "project" your data layer into your application's business logic domain. Think of the dictionary returned by a projector (the "projection") as the simplest possible domain object. Generally speaking, it's not necessary to write your own projector functions - you can simply wrap a producer function.
+
+```python
+from datetime import datetime
+
+def produce_age(instance):
+    return datetime.now().year - instance.birth_year
+
+project_age = projectors.wrap_producer("age", produce_age)
 
 author = Author(name="Some Author", birth_year=1984)
 print(project_age(author))
 #  {'age': 37}
 ```
 
-The simplest projector is one that returns the value of an object attribute, wrapped in a dictionary with the attribute name as its single key. `django-readers` provides a projector that does this:
-
-```python
-from django_readers import projectors
-
-author = Author(name="Some Author")
-project = projectors.attr("name")
-print(project(author))
-#  {'name': 'Some Author'}
-```
-
 A dictionary is returned because these projectors are intended to be _composable_: multiple simple projector functions can be combined into a more complex projector function that returns a dictionary containing the keys and values from all of its child projectors. This is done using the `projectors.combine` function:
 
 ```python
-from django_readers import projectors
+from django_readers import producers, projectors
 
 project = projectors.combine(
-    projectors.attr("name"),
+    projectors.wrap_producer("name", producers.attr("name")),
     project_age,
 )
 print(project(author))
@@ -123,108 +138,103 @@ print(project(author))
 
 This composition generally happens at the place in your codebase where the domain model is actually being _used_ (in a view, say). The projection will therefore contain precisely the keys needed by that view. This solves the problem of models becoming vast ever-growing flat namespaces containing all the functionality needed by all parts of your application.
 
-Related objects can also be projected using the `projectors.relationship` function, resulting in a nested projection:
+Related objects can also be produced using the `producers.relationship` function, resulting in a nested projection:
 
 ```python
 project = projectors.combine(
-    projectors.attr("name"),
+    projectors.wrap_producer("name", producers.attr("name")),
     project_age,
-    projectors.relationship("book_set", projectors.combine(
-        projectors.attr("title"),
-        projectors.attr("publication_year"),
+    projectors.wrap_producer("book_set", producers.relationship("book_set", projectors.combine(
+        projectors.wrap_producer(producers.attr("title")),
+        projectors.wrap_producer(producers.attr("publication_year"),
     )),
 )
 print(project(author))
 #  {'name': 'Some Author', 'age': 37, 'book_set': [{'title': 'Some Book', 'publication_year': 2019}]}
 ```
 
-Projectors can also be aliased, which means replacing one or more keys in the returned dictionary. If the projector to be aliased returns a dictionary with a single key, the `alias` function can be given a single string as its first argument, which will replace this key. If the projector returns multiple keys, a mapping of `{"old_name": "new_name"}` must be used.
+Note above that the second argument to `producers.relationship` is a projector function which projects each related object.
+
+The `producers.attr` function takes an optional argument `transform_value`, which is a function that receives the value of the attribute and returns a new value. This is useful if the value of the attribute needs to be converted in some way during projection.
+
+For example, imagine you have an `IntegerField` but you want the produced value to be a stringified version of the integer value. In that case, you can use `producers.attr("my_integer_field", transform_value=str)`.
+
+By default, the `transform_value` function is only called if the value of the attribute is not `None` (so in the example above, if the database value of `my_integer_field` is `NULL` then `None` would be returned, rather than the string `"None"`). If you want the `transform_value` function to _always_ be called, use `producers.attr("my_integer_field", transform_value=str, transform_value_if_none=True)`.
+
+Finally, the `producers.method` function will call the given method name on the instance, returning the result under a key matching the method name. Any extra arguments passed to `producers.method` will be passed along to the method.
+
+### `django_readers.producer_pairs` and `django_readers.projector_pairs`: "reader pairs" combining `prepare` with `produce` and `project`
+
+`prepare` and `produce` (and therefore also `project`) functions are intimately connected, with the `produce`/`project` functions usually depending on fields, annotations or relationships loaded by the `prepare` function. For this reason, `django-readers` expects these functions to live together in two-tuples: `(prepare, produce)` (a "producer pair") and ``(prepare, project)` (a "projector pair"). Remember that the difference between `produce` and `project` is that the former returns a single value, whereas the latter returns a dictionary binding one or more names (keys) to one or more values.
+
+In the example used above, the `produce_age` producer depends on the `birth_year` field:
 
 ```python
-project = projectors.alias(
-    "year_of_birth", projectors.attr("birth_year")
-)
+age_pair = (qs.include_fields("birth_year"), produce_age)
 ```
 
-The `projectors.attr` function takes an optional argument `transform_value`, which is a function that receives the value of the attribute and returns a new value. This is useful if the value of the attribute needs to be converted in some way during projection.
-
-For example, imagine you have an `IntegerField` but you want the projection to include a stringified version of the integer value. In that case, you can use `projectors.attr("my_integer_field", transform_value=str)`.
-
-By default, the `transform_value` function is only called if the value of the attribute is not `None` (so if the database value of `my_integer_field` is `NULL` then `None` would be returned, rather than the string `"None"`). If you want the `transform_value` function to _always_ be called, use `projectors.attr("my_integer_field", transform_value=str, transform_value_if_none=True)`.
-
-Finally, the `projectors.method` function will call the given method name on the instance, returning the result under a key matching the method name. Any extra arguments passed to `projectors.method` will be passed along to the method.
-
-### `django_readers.pairs`: "reader pairs" combining `prepare` and `project`
-
-`prepare` and `project` functions are intimately connected, with the `project` function usually depending on fields, annotations or relationships loaded by the `prepare` function. For this reason, `django-readers` expects these functions to live together in a two-tuple called a reader pair: `(prepare, project)`.
-
-In the example used above, the `project_age` projector depends on the `birth_year` field:
-
-```python
-age_pair = (qs.include_fields("birth_year"), project_age)
-```
-
-`django-readers` includes some useful functions that create pairs. These attempt to produce the most efficient queries they can, which means loading only those database fields which are required to project your query:
+`django-readers` includes some useful functions that create pairs. These attempt to produce the most efficient queries they can, which means loading only those database fields which are required to produce the value:
 
 ```python
 from django_readers import pairs
 
-prepare, project = pairs.field("name")
+prepare, produce = pairs.field("name")
 queryset = prepare(Author.objects.all())
 print(queryset.query)
 #  SELECT "author"."id", "author"."name" FROM "author"
-result = project(queryset.first())
+result = produce(queryset.first())
 print(project(author))
-#  {'name': 'Some Author'}
+#  'Some Author'
 ```
 
-The `pairs.field` function takes the same `transform_value` and `transform_value_if_none` arguments as `projectors.attr` (see above).
+The `pairs.field` function takes the same `transform_value` and `transform_value_if_none` arguments as `producers.attr` (see above).
+
+When composing multiple pairs together, it is again necessary to wrap the producer to convert it to a projector, thus forming `(prepare, project)` pairs. This can be done with the `pairs.wrap_producer` function:
+
+```python
+prepare, project = pairs.combine_projectors(
+    pairs.wrap_producer("name", pairs.field("name")),
+    pairs.wrap_producer("birth_year", pairs.field("birth_year")),
+)
+```
 
 Relationships can automatically be loaded and projected, too:
 
 ```python
-prepare, project = pairs.combine(
-    pairs.field("name"),
+prepare, project = pairs.combine_projectors(
+    pairs.wrap_producer("name", pairs.field("name")),
     age_pair,
-    pairs.relationship("book_set", pairs.combine(
-        pairs.field("title"),
-        pairs.field("publication_year"),
-    ))
+    pairs.wrap_producer("book_set", pairs.relationship("book_set", pairs.combine_projectors(
+        pairs.wrap_producer("title", pairs.field("title")),
+        pairs.wrap_producer("publication_year", pairs.field("publication_year")),
+    )))
 )
 ```
 
-Again, only the precise fields that are needed are loaded from the database. All relationship functions take an optional `to_attr` argument which is passed to the underlying `Prefetch` object and also changes the key name in the projection.
+Again, only the precise fields that are needed are loaded from the database. All relationship functions take an optional `to_attr` argument which is passed to the underlying `Prefetch` object and also changes the key name used by the producer.
 
 Note that `django-readers` _always_ uses `prefetch_related` to load relationships, even in circumstances where `select_related` would usually be used (ie `ForeignKey` and `OneToOneField`), resulting in one query per relationship. This approach allows the code to be "fractal": the tree of `(prepare, project)` pairs can be recursively applied to the tree of related querysets.
 
 Of course, it is quite possible to use `select_related` by applying `qs.select_related` at the root of your query, but this must be done manually. `django-readers` also provides `qs.select_related_fields`, which combines `select_related` with `include_fields` to allow you to specify exactly which fields you need from the related objects.
 
-You can use `pairs.pk_list` to project a list containing just the primary keys of the related objects.
+You can use `pairs.pk_list` to produce a list containing just the primary keys of the related objects.
 
-It is also possible to wrap a pair in `pairs.alias`, which takes the same alias argument as `projectors.alias` (see above), and applies it to the projector part of the pair:
-
-```python
-prepare, project = pairs.alias(
-    "year_of_birth", pairs.field("birth_year")
-)
-```
-
-As a shortcut, the `pairs` module provides functions called `filter`, `exclude` and `order_by`, which can be used to apply the given queryset functions to the queryset without affecting the projection. These are equivalent to (for example) `(qs.filter(arg=value), projectors.noop)` and are most useful for filtering or ordering related objects:
+As a shortcut, the `pairs` module provides functions called `filter`, `exclude` and `order_by`, which can be used to apply the given queryset functions to the queryset _without affecting the projection_. These are equivalent to (for example) `(qs.filter(arg=value), projectors.noop)` and are most useful for filtering or ordering related objects:
 
 ```python
-prepare, project = pairs.combine(
-    pairs.field("name"),
+prepare, project = pairs.combine_projectors(
+    pairs.wrap_producer("name", pairs.field("name")),
     age_pair,
-    pairs.relationship(
+    pairs.wrap_producer("book_set", pairs.relationship(
         "book_set",
-        pairs.combine(
+        pairs.combine_projectors(
             pairs.filter(publication_year__gte=2020),
             pairs.order_by("title"),
-            pairs.field("title"),
-            pairs.field("publication_year"),
+            pairs.wrap_producer("title", pairs.field("title")),
+            pairs.wrap_producer("publication_year", pairs.field("publication_year")),
         ),
         to_attr="recent_books"
-    )
+    ))
 )
 ```
 
@@ -232,20 +242,20 @@ prepare, project = pairs.combine(
 
 > For every field that has `choices` set, the object will have a `get_FOO_display()` method, where `FOO` is the name of the field. This method returns the “human-readable” value of the field.
 
-The `pairs.field_display` function takes the field name as its single argument and returns a pair which loads the field from the database, and then projects the result of calling `get_<field>_display` under the key `<field>_display`.
+The `pairs.field_display` function takes the field name as its single argument and returns a pair which loads the field from the database, and then produces the result of calling `get_<field>_display`.
 
-Finally, `pairs.count` and `pairs.has` provide shortcuts to annotate a queryset with the count or existence of related objects, and project these values under the keys `<relationship_name>_count` and `has_<relationship_name>` respectively.
+Finally, `pairs.count` and `pairs.has` provide shortcuts to annotate a queryset with the count or existence of related objects, and produce these values.
 
 ### `django_readers.specs`: a high-level specification for efficient data querying and projection
 
-This layer is the real magic of `django-readers`: a straightforward way of specifying the shape of your data in order to efficiently select and project a complex tree of related objects.
+Manually assembling trees of pairs as seen above may seem long-winded. The `specs` module provides a layer of syntactic sugar that makes it much easier. This layer is the real magic of `django-readers`: a straightforward way of specifying the shape of your data in order to efficiently select and project a complex tree of related objects.
 
-The resulting nested dictionary structure may be returned from as view as a JSON response (assuming all your projectors return JSON-serializable values), or included in a template context in place of a queryset or model instance.
+The resulting nested dictionary structure may be returned from as view as a JSON response (assuming all your producers return JSON-serializable values), or included in a template context in place of a queryset or model instance.
 
 A spec is a list. Under the hood, the `specs` module is a very lightweight wrapper on top of `pairs` - it applies simple transformations to the items in the list to replace them with the relevant pair functions. The list may contain:
 
 * _strings_, which are interpreted as field names and are replaced with `pairs.field`,
-* _dictionaries_, which are interpreted as relationships (with the keys specifying the relationship name and the values being specs for projecting the related objects) and are replaced with `pairs.relationship`.
+* _dictionaries_, which serve two purposes: if the value is a list, they are interpreted as relationships (with the keys specifying the relationship name and the values being specs for projecting the related objects) and are replaced with `pairs.relationship`. If the value is anything else (a string or a pair), the value returned by the produce function in the pair is projected under the specified key.
 * _pairs_ of `(prepare, project)` functions (see previous section), which are left as-is.
 
 The example from the last section may be written as the following spec:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ from datetime import datetime
 def produce_age(instance):
     return datetime.now().year - instance.birth_year
 
-project_age = projectors.wrap_producer("age", produce_age)
+project_age = projectors.producer_to_projector("age", produce_age)
 
 author = Author(name="Some Author", birth_year=1984)
 print(project_age(author))
@@ -129,7 +129,7 @@ A dictionary is returned because these projectors are intended to be _composable
 from django_readers import producers, projectors
 
 project = projectors.combine(
-    projectors.wrap_producer("name", producers.attr("name")),
+    projectors.producer_to_projector("name", producers.attr("name")),
     project_age,
 )
 print(project(author))
@@ -142,11 +142,11 @@ Related objects can also be produced using the `producers.relationship` function
 
 ```python
 project = projectors.combine(
-    projectors.wrap_producer("name", producers.attr("name")),
+    projectors.producer_to_projector("name", producers.attr("name")),
     project_age,
-    projectors.wrap_producer("book_set", producers.relationship("book_set", projectors.combine(
-        projectors.wrap_producer(producers.attr("title")),
-        projectors.wrap_producer(producers.attr("publication_year"),
+    projectors.producer_to_projector("book_set", producers.relationship("book_set", projectors.combine(
+        projectors.producer_to_projector(producers.attr("title")),
+        projectors.producer_to_projector(producers.attr("publication_year"),
     )),
 )
 print(project(author))
@@ -189,12 +189,12 @@ print(project(author))
 
 The `pairs.field` function takes the same `transform_value` and `transform_value_if_none` arguments as `producers.attr` (see above).
 
-When composing multiple pairs together, it is again necessary to wrap the producer to convert it to a projector, thus forming `(prepare, project)` pairs. This can be done with the `pairs.wrap_producer` function:
+When composing multiple pairs together, it is again necessary to wrap the producer to convert it to a projector, thus forming `(prepare, project)` pairs. This can be done with the `pairs.producer_to_projector` function:
 
 ```python
 prepare, project = pairs.combine(
-    pairs.wrap_producer("name", pairs.field("name")),
-    pairs.wrap_producer("birth_year", pairs.field("birth_year")),
+    pairs.producer_to_projector("name", pairs.field("name")),
+    pairs.producer_to_projector("birth_year", pairs.field("birth_year")),
 )
 ```
 
@@ -202,11 +202,11 @@ Relationships can automatically be loaded and projected, too:
 
 ```python
 prepare, project = pairs.combine(
-    pairs.wrap_producer("name", pairs.field("name")),
+    pairs.producer_to_projector("name", pairs.field("name")),
     age_pair,
-    pairs.wrap_producer("book_set", pairs.relationship("book_set", pairs.combine(
-        pairs.wrap_producer("title", pairs.field("title")),
-        pairs.wrap_producer("publication_year", pairs.field("publication_year")),
+    pairs.producer_to_projector("book_set", pairs.relationship("book_set", pairs.combine(
+        pairs.producer_to_projector("title", pairs.field("title")),
+        pairs.producer_to_projector("publication_year", pairs.field("publication_year")),
     )))
 )
 ```
@@ -223,15 +223,15 @@ As a shortcut, the `pairs` module provides functions called `filter`, `exclude` 
 
 ```python
 prepare, project = pairs.combine(
-    pairs.wrap_producer("name", pairs.field("name")),
+    pairs.producer_to_projector("name", pairs.field("name")),
     age_pair,
-    pairs.wrap_producer("book_set", pairs.relationship(
+    pairs.producer_to_projector("book_set", pairs.relationship(
         "book_set",
         pairs.combine(
             pairs.filter(publication_year__gte=2020),
             pairs.order_by("title"),
-            pairs.wrap_producer("title", pairs.field("title")),
-            pairs.wrap_producer("publication_year", pairs.field("publication_year")),
+            pairs.producer_to_projector("title", pairs.field("title")),
+            pairs.producer_to_projector("publication_year", pairs.field("publication_year")),
         ),
         to_attr="recent_books"
     ))

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The `pairs.field` function takes the same `transform_value` and `transform_value
 When composing multiple pairs together, it is again necessary to wrap the producer to convert it to a projector, thus forming `(prepare, project)` pairs. This can be done with the `pairs.wrap_producer` function:
 
 ```python
-prepare, project = pairs.combine_projectors(
+prepare, project = pairs.combine(
     pairs.wrap_producer("name", pairs.field("name")),
     pairs.wrap_producer("birth_year", pairs.field("birth_year")),
 )
@@ -201,10 +201,10 @@ prepare, project = pairs.combine_projectors(
 Relationships can automatically be loaded and projected, too:
 
 ```python
-prepare, project = pairs.combine_projectors(
+prepare, project = pairs.combine(
     pairs.wrap_producer("name", pairs.field("name")),
     age_pair,
-    pairs.wrap_producer("book_set", pairs.relationship("book_set", pairs.combine_projectors(
+    pairs.wrap_producer("book_set", pairs.relationship("book_set", pairs.combine(
         pairs.wrap_producer("title", pairs.field("title")),
         pairs.wrap_producer("publication_year", pairs.field("publication_year")),
     )))
@@ -222,12 +222,12 @@ You can use `pairs.pk_list` to produce a list containing just the primary keys o
 As a shortcut, the `pairs` module provides functions called `filter`, `exclude` and `order_by`, which can be used to apply the given queryset functions to the queryset _without affecting the projection_. These are equivalent to (for example) `(qs.filter(arg=value), projectors.noop)` and are most useful for filtering or ordering related objects:
 
 ```python
-prepare, project = pairs.combine_projectors(
+prepare, project = pairs.combine(
     pairs.wrap_producer("name", pairs.field("name")),
     age_pair,
     pairs.wrap_producer("book_set", pairs.relationship(
         "book_set",
-        pairs.combine_projectors(
+        pairs.combine(
             pairs.filter(publication_year__gte=2020),
             pairs.order_by("title"),
             pairs.wrap_producer("title", pairs.field("title")),

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The resulting nested dictionary structure may be returned from as view as a JSON
 A spec is a list. Under the hood, the `specs` module is a very lightweight wrapper on top of `pairs` - it applies simple transformations to the items in the list to replace them with the relevant pair functions. The list may contain:
 
 * _strings_, which are interpreted as field names and are replaced with `pairs.field`,
-* _dictionaries_, which serve two purposes: if the value is a list, they are interpreted as relationships (with the keys specifying the relationship name and the values being specs for projecting the related objects) and are replaced with `pairs.relationship`. If the value is anything else (a string or a pair), the value returned by the produce function in the pair is projected under the specified key.
+* _dictionaries_, which serve two purposes: if the value is a list, they are interpreted as relationships (with the keys specifying the relationship name and the values being specs for projecting the related objects) and are replaced with `pairs.relationship`. If the value is anything else (a string or a `(prepare, produce)` pair), the value returned by the produce function in the pair is projected under the specified key.
 * _pairs_ of `(prepare, project)` functions (see previous section), which are left as-is.
 
 The example from the last section may be written as the following spec:

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ By default, the `transform_value` function is only called if the value of the at
 
 Finally, the `producers.method` function will call the given method name on the instance, returning the result under a key matching the method name. Any extra arguments passed to `producers.method` will be passed along to the method.
 
-### `django_readers.producer_pairs` and `django_readers.projector_pairs`: "reader pairs" combining `prepare` with `produce` and `project`
+### `django_readers.pairs`: "reader pairs" combining `prepare` with `produce` and `project`
 
 `prepare` and `produce` (and therefore also `project`) functions are intimately connected, with the `produce`/`project` functions usually depending on fields, annotations or relationships loaded by the `prepare` function. For this reason, `django-readers` expects these functions to live together in two-tuples: `(prepare, produce)` (a "producer pair") and ``(prepare, project)` (a "projector pair"). Remember that the difference between `produce` and `project` is that the former returns a single value, whereas the latter returns a dictionary binding one or more names (keys) to one or more values.
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -2,9 +2,9 @@ from django.db.models import Count
 from django_readers import producers, projectors, qs
 
 
-def wrap_producer(name, pair):
+def producer_to_projector(name, pair):
     prepare, produce = pair
-    return prepare, projectors.wrap_producer(name, produce)
+    return prepare, projectors.producer_to_projector(name, produce)
 
 
 def field(name, *, transform_value=None, transform_value_if_none=False):

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -1,9 +1,14 @@
 from django.db.models import Count
-from django_readers import projectors, qs
+from django_readers import producers, projectors, qs
+
+
+def wrap_producer(name, pair):
+    prepare, produce = pair
+    return prepare, projectors.wrap_producer(name, produce)
 
 
 def field(name, *, transform_value=None, transform_value_if_none=False):
-    return qs.include_fields(name), projectors.attr(
+    return qs.include_fields(name), producers.attr(
         name,
         transform_value=transform_value,
         transform_value_if_none=transform_value_if_none,
@@ -17,11 +22,6 @@ def combine(*pairs):
     """
     prepare_fns, project_fns = zip(*pairs)
     return qs.pipe(*prepare_fns), projectors.combine(*project_fns)
-
-
-def alias(alias_or_aliases, pair):
-    prepare, project = pair
-    return prepare, projectors.alias(alias_or_aliases, project)
 
 
 def prepare_only(prepare):
@@ -38,16 +38,14 @@ def field_display(name):
     the name of a field, calls get_<name>_display, and returns a projector that puts
     the returned value under the key <name>_display.
     """
-    return qs.include_fields(name), projectors.alias(
-        f"{name}_display", projectors.method(f"get_{name}_display")
-    )
+    return qs.include_fields(name), producers.method(f"get_{name}_display")
 
 
 def count(name, distinct=True):
     attr_name = f"{name}_count"
     return (
         qs.annotate(**{attr_name: Count(name, distinct=distinct)}),
-        projectors.attr(attr_name),
+        producers.attr(attr_name),
     )
 
 
@@ -55,9 +53,7 @@ def has(name, distinct=True):
     attr_name = f"{name}_count"
     return (
         qs.annotate(**{attr_name: Count(name, distinct=distinct)}),
-        projectors.alias(
-            f"has_{name}", projectors.attr(attr_name, transform_value=bool)
-        ),
+        producers.attr(attr_name, transform_value=bool),
     )
 
 
@@ -75,7 +71,7 @@ def order_by(*args, **kwargs):
 
 """
 Below are pair functions which return the various queryset functions that prefetch
-relationships of various types, and then project those related objects.
+relationships of various types, and then produce those related objects.
 
 There are functions for forward, reverse or many-to-many relationships, and then
 a `relationship` function which selects the correct one by introspecting the
@@ -89,7 +85,7 @@ def forward_relationship(name, related_queryset, relationship_pair, to_attr=None
     prepare = qs.prefetch_forward_relationship(
         name, related_queryset, prepare_related_queryset, to_attr
     )
-    return prepare, projectors.relationship(to_attr or name, project_relationship)
+    return prepare, producers.relationship(to_attr or name, project_relationship)
 
 
 def reverse_relationship(
@@ -99,7 +95,7 @@ def reverse_relationship(
     prepare = qs.prefetch_reverse_relationship(
         name, related_name, related_queryset, prepare_related_queryset, to_attr
     )
-    return prepare, projectors.relationship(to_attr or name, project_relationship)
+    return prepare, producers.relationship(to_attr or name, project_relationship)
 
 
 def many_to_many_relationship(name, related_queryset, relationship_pair, to_attr=None):
@@ -107,17 +103,17 @@ def many_to_many_relationship(name, related_queryset, relationship_pair, to_attr
     prepare = qs.prefetch_many_to_many_relationship(
         name, related_queryset, prepare_related_queryset, to_attr
     )
-    return prepare, projectors.relationship(to_attr or name, project_relationship)
+    return prepare, producers.relationship(to_attr or name, project_relationship)
 
 
 def relationship(name, relationship_pair, to_attr=None):
     prepare_related_queryset, project_relationship = relationship_pair
     prepare = qs.auto_prefetch_relationship(name, prepare_related_queryset, to_attr)
-    return prepare, projectors.relationship(to_attr or name, project_relationship)
+    return prepare, producers.relationship(to_attr or name, project_relationship)
 
 
 def pk_list(name, to_attr=None):
     return (
         qs.auto_prefetch_relationship(name, qs.include_fields("pk"), to_attr=to_attr),
-        projectors.pk_list(to_attr or name),
+        producers.pk_list(to_attr or name),
     )

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -35,8 +35,7 @@ def project_only(project):
 def field_display(name):
     """
     Works with Django's get_FOO_display mechanism for fields with choices set. Given
-    the name of a field, calls get_<name>_display, and returns a projector that puts
-    the returned value under the key <name>_display.
+    the name of a field, returns a producer that calls get_<name>_display.
     """
     return qs.include_fields(name), producers.method(f"get_{name}_display")
 

--- a/django_readers/producers.py
+++ b/django_readers/producers.py
@@ -1,0 +1,44 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django_readers.utils import map_or_apply, none_safe_attrgetter
+from operator import attrgetter, methodcaller
+
+
+def attr(name, *, transform_value=None, transform_value_if_none=False):
+    def producer(instance):
+        value = none_safe_attrgetter(name)(instance)
+        if transform_value and (value is not None or transform_value_if_none):
+            value = transform_value(value)
+        return value
+
+    return producer
+
+
+method = methodcaller
+
+
+def relationship(name, related_projector):
+    """
+    Given an attribute name and a projector, return a producer which plucks
+    the attribute off the instance, figures out whether it represents a single
+    object or an iterable/queryset of objects, and applies the given projector
+    to the related object or objects.
+    """
+
+    def producer(instance):
+        try:
+            related = none_safe_attrgetter(name)(instance)
+        except ObjectDoesNotExist:
+            return None
+        return map_or_apply(related, related_projector)
+
+    return producer
+
+
+def pk_list(name):
+    """
+    Given an attribute name (which should be a relationship field), return a
+    producer which returns a list of the PK of each item in the relationship (or
+    just a single PK if this is a to-one field, but this is an inefficient way of
+    doing it).
+    """
+    return relationship(name, attrgetter("pk"))

--- a/django_readers/projectors.py
+++ b/django_readers/projectors.py
@@ -1,4 +1,4 @@
-def wrap_producer(key, producer):
+def producer_to_projector(key, producer):
     def projector(instance):
         return {key: producer(instance)}
 

--- a/django_readers/projectors.py
+++ b/django_readers/projectors.py
@@ -1,55 +1,8 @@
-from django.core.exceptions import ObjectDoesNotExist
-from django_readers.utils import map_or_apply, none_safe_attrgetter
-from operator import attrgetter, methodcaller
-
-
-def wrap(key, value_getter):
+def wrap_producer(key, producer):
     def projector(instance):
-        return {key: value_getter(instance)}
+        return {key: producer(instance)}
 
     return projector
-
-
-def attr(name, *, transform_value=None, transform_value_if_none=False):
-    def value_getter(instance):
-        value = none_safe_attrgetter(name)(instance)
-        if transform_value and (value is not None or transform_value_if_none):
-            value = transform_value(value)
-        return value
-
-    return wrap(name, value_getter)
-
-
-def method(name, *args, **kwargs):
-    return wrap(name, methodcaller(name, *args, **kwargs))
-
-
-def relationship(name, related_projector):
-    """
-    Given an attribute name and a projector, return a projector which plucks
-    the attribute off the instance, figures out whether it represents a single
-    object or an iterable/queryset of objects, and applies the given projector
-    to the related object or objects.
-    """
-
-    def value_getter(instance):
-        try:
-            related = none_safe_attrgetter(name)(instance)
-        except ObjectDoesNotExist:
-            return None
-        return map_or_apply(related, related_projector)
-
-    return wrap(name, value_getter)
-
-
-def pk_list(name):
-    """
-    Given an attribute name (which should be a relationship field), return a
-    projector which returns a list of the PK of each item in the relationship (or
-    just a single PK if this is a to-one field, but this is an inefficient way of
-    doing it).
-    """
-    return relationship(name, attrgetter("pk"))
 
 
 def combine(*projectors):
@@ -61,41 +14,13 @@ def combine(*projectors):
     def combined(instance):
         result = {}
         for projector in projectors:
-            result.update(projector(instance))
+            projection = projector(instance)
+            if not isinstance(projection, dict):
+                raise TypeError(f"Projector {projector} did not return a dictionary")
+            result.update(projection)
         return result
 
     return combined
-
-
-def alias(alias_or_aliases, projector):
-    """
-    Given a projector and a dictionary of aliases {"old_key_name": "new_key_name"},
-    return a projector which replaces the keys in the output of the original projector
-    with those provided in the alias map. As a shortcut, the argument can be a single
-    string, in which case this will automatically alias a single-key projector without
-    needing to know the key name of key in the dictionary returned from the
-    inner projector.
-    """
-
-    def aliaser(instance):
-        projected = projector(instance)
-        if isinstance(alias_or_aliases, str) and len(projected) != 1:
-            raise TypeError(
-                "A single string can only be used as an alias for projectors "
-                "that return a dictionary with a single key. Please use a mapping "
-                "to define aliases instead."
-            )
-
-        alias_map = (
-            {next(iter(projected)): alias_or_aliases}
-            if isinstance(alias_or_aliases, str)
-            else alias_or_aliases
-        )
-        for old, new in alias_map.items():
-            projected[new] = projected.pop(old)
-        return projected
-
-    return aliaser
 
 
 def noop(instance):

--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -31,6 +31,8 @@ def relationship_or_wrap(name, child_spec):
     if isinstance(child_spec, list):
         return relationship(name, child_spec)
     if isinstance(child_spec, dict):
+        if len(child_spec) != 1:
+            raise ValueError("Aliased relationship spec must contain only one key")
         relationship_name, relationship_spec = next(iter(child_spec.items()))
         return pairs.wrap_producer(
             name, pairs.relationship(relationship_name, process(relationship_spec))

--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -27,14 +27,14 @@ def relationship(name, relationship_spec, to_attr=None):
 
 def relationship_or_wrap(name, child_spec):
     if isinstance(child_spec, str):
-        return pairs.wrap_producer(name, pairs.field(child_spec))
-    if isinstance(child_spec, list):
-        return relationship(name, child_spec)
-    if isinstance(child_spec, dict):
+        producer = pairs.field(child_spec)
+    elif isinstance(child_spec, list):
+        producer = pairs.relationship(name, process(child_spec))
+    elif isinstance(child_spec, dict):
         if len(child_spec) != 1:
             raise ValueError("Aliased relationship spec must contain only one key")
         relationship_name, relationship_spec = next(iter(child_spec.items()))
-        return pairs.wrap_producer(
-            name, pairs.relationship(relationship_name, process(relationship_spec))
-        )
-    return pairs.wrap_producer(name, child_spec)
+        producer = pairs.relationship(relationship_name, process(relationship_spec))
+    else:
+        producer = child_spec
+    return pairs.wrap_producer(name, producer)

--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -4,7 +4,7 @@ from django_readers.utils import queries_disabled
 
 def process_item(item):
     if isinstance(item, str):
-        return pairs.field(item)
+        return pairs.wrap_producer(item, pairs.field(item))
     if isinstance(item, dict):
         return pairs.combine(
             *[
@@ -19,9 +19,7 @@ def process(spec):
     return queries_disabled(pairs.combine(*(process_item(item) for item in spec)))
 
 
-def alias(alias_or_aliases, item):
-    return pairs.alias(alias_or_aliases, process_item(item))
-
-
 def relationship(name, relationship_spec, to_attr=None):
-    return pairs.relationship(name, process(relationship_spec), to_attr)
+    return pairs.wrap_producer(
+        to_attr or name, pairs.relationship(name, process(relationship_spec), to_attr)
+    )

--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -4,12 +4,12 @@ from django_readers.utils import queries_disabled
 
 def process_item(item):
     if isinstance(item, str):
-        return pairs.wrap_producer(item, pairs.field(item))
+        item = {item: item}
     if isinstance(item, dict):
         return pairs.combine(
             *[
-                relationship(name, relationship_spec)
-                for name, relationship_spec in item.items()
+                relationship_or_wrap(name, child_spec)
+                for name, child_spec in item.items()
             ]
         )
     return item
@@ -23,3 +23,16 @@ def relationship(name, relationship_spec, to_attr=None):
     return pairs.wrap_producer(
         to_attr or name, pairs.relationship(name, process(relationship_spec), to_attr)
     )
+
+
+def relationship_or_wrap(name, child_spec):
+    if isinstance(child_spec, str):
+        return pairs.wrap_producer(name, pairs.field(child_spec))
+    if isinstance(child_spec, list):
+        return relationship(name, child_spec)
+    if isinstance(child_spec, dict):
+        relationship_name, relationship_spec = next(iter(child_spec.items()))
+        return pairs.wrap_producer(
+            name, pairs.relationship(relationship_name, process(relationship_spec))
+        )
+    return pairs.wrap_producer(name, child_spec)

--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -20,7 +20,7 @@ def process(spec):
 
 
 def relationship(name, relationship_spec, to_attr=None):
-    return pairs.wrap_producer(
+    return pairs.producer_to_projector(
         to_attr or name, pairs.relationship(name, process(relationship_spec), to_attr)
     )
 
@@ -37,4 +37,4 @@ def relationship_or_wrap(name, child_spec):
         producer = pairs.relationship(relationship_name, process(relationship_spec))
     else:
         producer = child_spec
-    return pairs.wrap_producer(name, producer)
+    return pairs.producer_to_projector(name, producer)

--- a/django_readers/specs.py
+++ b/django_readers/specs.py
@@ -27,14 +27,16 @@ def relationship(name, relationship_spec, to_attr=None):
 
 def relationship_or_wrap(name, child_spec):
     if isinstance(child_spec, str):
-        producer = pairs.field(child_spec)
+        producer_pair = pairs.field(child_spec)
     elif isinstance(child_spec, list):
-        producer = pairs.relationship(name, process(child_spec))
+        producer_pair = pairs.relationship(name, process(child_spec))
     elif isinstance(child_spec, dict):
         if len(child_spec) != 1:
             raise ValueError("Aliased relationship spec must contain only one key")
         relationship_name, relationship_spec = next(iter(child_spec.items()))
-        producer = pairs.relationship(relationship_name, process(relationship_spec))
+        producer_pair = pairs.relationship(
+            relationship_name, process(relationship_spec)
+        )
     else:
-        producer = child_spec
-    return pairs.producer_to_projector(name, producer)
+        producer_pair = child_spec
+    return pairs.producer_to_projector(name, producer_pair)

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
-from django_readers import pairs, projectors, qs
+from django_readers import pairs, producers, projectors, qs
 from tests.models import Category, Group, Owner, Thing, Widget
-from tests.test_projectors import title_and_reverse
+from tests.test_producers import title_and_reverse
 
 
 class PairsTestCase(TestCase):
@@ -10,8 +10,8 @@ class PairsTestCase(TestCase):
             Widget.objects.create(name=name, other=f"other-{name}")
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.field("other"),
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer("other", pairs.field("other")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -31,9 +31,16 @@ class PairsTestCase(TestCase):
         Widget.objects.create(name=None, other=None)
 
         prepare, project = pairs.combine(
-            pairs.field("name", transform_value=title_and_reverse),
-            pairs.field(
-                "other", transform_value=title_and_reverse, transform_value_if_none=True
+            pairs.wrap_producer(
+                "name", pairs.field("name", transform_value=title_and_reverse)
+            ),
+            pairs.wrap_producer(
+                "other",
+                pairs.field(
+                    "other",
+                    transform_value=title_and_reverse,
+                    transform_value_if_none=True,
+                ),
             ),
         )
 
@@ -54,16 +61,22 @@ class PairsTestCase(TestCase):
         Widget.objects.create(name="test widget", owner=owner)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.forward_relationship(
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
                 "owner",
-                Owner.objects.all(),
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.forward_relationship(
-                        "group",
-                        Group.objects.all(),
-                        pairs.field("name"),
+                pairs.forward_relationship(
+                    "owner",
+                    Owner.objects.all(),
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "group",
+                            pairs.forward_relationship(
+                                "group",
+                                Group.objects.all(),
+                                pairs.wrap_producer("name", pairs.field("name")),
+                            ),
+                        ),
                     ),
                 ),
             ),
@@ -93,12 +106,15 @@ class PairsTestCase(TestCase):
         )
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.forward_relationship(
-                "owner",
-                Owner.objects.all(),
-                pairs.field("name"),
-                to_attr="owner_attr",
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
+                "owner_attr",
+                pairs.forward_relationship(
+                    "owner",
+                    Owner.objects.all(),
+                    pairs.wrap_producer("name", pairs.field("name")),
+                    to_attr="owner_attr",
+                ),
             ),
         )
 
@@ -122,18 +138,24 @@ class PairsTestCase(TestCase):
         Widget.objects.create(name="widget 3", owner=owner_2)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.reverse_relationship(
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
                 "owner_set",
-                "group",
-                Owner.objects.all(),
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.reverse_relationship(
-                        "widget_set",
-                        "owner",
-                        Widget.objects.all(),
-                        pairs.field("name"),
+                pairs.reverse_relationship(
+                    "owner_set",
+                    "group",
+                    Owner.objects.all(),
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "widget_set",
+                            pairs.reverse_relationship(
+                                "widget_set",
+                                "owner",
+                                Widget.objects.all(),
+                                pairs.wrap_producer("name", pairs.field("name")),
+                            ),
+                        ),
                     ),
                 ),
             ),
@@ -176,13 +198,16 @@ class PairsTestCase(TestCase):
         Owner.objects.create(name="owner 2", group=group)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.reverse_relationship(
-                "owner_set",
-                "group",
-                Owner.objects.all(),
-                pairs.field("name"),
-                to_attr="owner_set_attr",
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
+                "owner_set_attr",
+                pairs.reverse_relationship(
+                    "owner_set",
+                    "group",
+                    Owner.objects.all(),
+                    pairs.wrap_producer("name", pairs.field("name")),
+                    to_attr="owner_set_attr",
+                ),
             ),
         )
 
@@ -205,17 +230,23 @@ class PairsTestCase(TestCase):
         Thing.objects.create(name="test thing", widget=widget)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.forward_relationship(
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
                 "widget",
-                Widget.objects.all(),
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.reverse_relationship(
-                        "thing",
-                        "widget",
-                        Thing.objects.all(),
-                        pairs.field("name"),
+                pairs.forward_relationship(
+                    "widget",
+                    Widget.objects.all(),
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "thing",
+                            pairs.reverse_relationship(
+                                "thing",
+                                "widget",
+                                Thing.objects.all(),
+                                pairs.wrap_producer("name", pairs.field("name")),
+                            ),
+                        ),
                     ),
                 ),
             ),
@@ -243,21 +274,27 @@ class PairsTestCase(TestCase):
         Thing.objects.create(name="test thing", widget=widget)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.forward_relationship(
-                "widget",
-                Widget.objects.all(),
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.reverse_relationship(
-                        "thing",
-                        "widget",
-                        Thing.objects.all(),
-                        pairs.field("name"),
-                        to_attr="thing_attr",
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
+                "widget_attr",
+                pairs.forward_relationship(
+                    "widget",
+                    Widget.objects.all(),
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "thing_attr",
+                            pairs.reverse_relationship(
+                                "thing",
+                                "widget",
+                                Thing.objects.all(),
+                                pairs.wrap_producer("name", pairs.field("name")),
+                                to_attr="thing_attr",
+                            ),
+                        ),
                     ),
+                    to_attr="widget_attr",
                 ),
-                to_attr="widget_attr",
             ),
         )
 
@@ -281,16 +318,22 @@ class PairsTestCase(TestCase):
         category.widget_set.add(widget)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.many_to_many_relationship(
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
                 "widget_set",
-                Widget.objects.all(),
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.many_to_many_relationship(
-                        "category_set",
-                        Category.objects.all(),
-                        pairs.field("name"),
+                pairs.many_to_many_relationship(
+                    "widget_set",
+                    Widget.objects.all(),
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "category_set",
+                            pairs.many_to_many_relationship(
+                                "category_set",
+                                Category.objects.all(),
+                                pairs.wrap_producer("name", pairs.field("name")),
+                            ),
+                        ),
                     ),
                 ),
             ),
@@ -321,20 +364,26 @@ class PairsTestCase(TestCase):
         category.widget_set.add(widget)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.many_to_many_relationship(
-                "widget_set",
-                Widget.objects.all(),
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.many_to_many_relationship(
-                        "category_set",
-                        Category.objects.all(),
-                        pairs.field("name"),
-                        to_attr="category_set_attr",
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
+                "widget_set_attr",
+                pairs.many_to_many_relationship(
+                    "widget_set",
+                    Widget.objects.all(),
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "category_set_attr",
+                            pairs.many_to_many_relationship(
+                                "category_set",
+                                Category.objects.all(),
+                                pairs.wrap_producer("name", pairs.field("name")),
+                                to_attr="category_set_attr",
+                            ),
+                        ),
                     ),
+                    to_attr="widget_set_attr",
                 ),
-                to_attr="widget_set_attr",
             ),
         )
 
@@ -362,29 +411,53 @@ class PairsTestCase(TestCase):
         Thing.objects.create(name="test thing", widget=widget)
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.relationship(
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
                 "owner",
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.relationship(
-                        "widget_set",
-                        pairs.field("name"),
+                pairs.relationship(
+                    "owner",
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "widget_set",
+                            pairs.relationship(
+                                "widget_set",
+                                pairs.wrap_producer("name", pairs.field("name")),
+                            ),
+                        ),
                     ),
                 ),
             ),
-            pairs.relationship(
+            pairs.wrap_producer(
                 "category_set",
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.relationship("widget_set", pairs.field("name")),
+                pairs.relationship(
+                    "category_set",
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "widget_set",
+                            pairs.relationship(
+                                "widget_set",
+                                pairs.wrap_producer("name", pairs.field("name")),
+                            ),
+                        ),
+                    ),
                 ),
             ),
-            pairs.relationship(
+            pairs.wrap_producer(
                 "thing",
-                pairs.combine(
-                    pairs.field("name"),
-                    pairs.relationship("widget", pairs.field("name")),
+                pairs.relationship(
+                    "thing",
+                    pairs.combine(
+                        pairs.wrap_producer("name", pairs.field("name")),
+                        pairs.wrap_producer(
+                            "widget",
+                            pairs.relationship(
+                                "widget",
+                                pairs.wrap_producer("name", pairs.field("name")),
+                            ),
+                        ),
+                    ),
                 ),
             ),
         )
@@ -419,11 +492,14 @@ class PairsTestCase(TestCase):
         )
 
         prepare, project = pairs.combine(
-            pairs.field("name"),
-            pairs.relationship(
-                "owner",
-                pairs.field("name"),
-                to_attr="owner_attr",
+            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.wrap_producer(
+                "owner_attr",
+                pairs.relationship(
+                    "owner",
+                    pairs.wrap_producer("name", pairs.field("name")),
+                    to_attr="owner_attr",
+                ),
             ),
         )
 
@@ -440,34 +516,6 @@ class PairsTestCase(TestCase):
             },
         )
 
-    def test_alias(self):
-        owner = Owner.objects.create(name="test owner")
-        Widget.objects.create(name="test widget", owner=owner)
-
-        prepare, project = pairs.combine(
-            pairs.alias("name_alias", pairs.field("name")),
-            pairs.alias(
-                {"widget_set": "widgets"},
-                pairs.relationship(
-                    "widget_set",
-                    pairs.alias({"name": "alias"}, pairs.field("name")),
-                ),
-            ),
-        )
-
-        with self.assertNumQueries(0):
-            queryset = prepare(Owner.objects.all())
-
-        with self.assertNumQueries(2):
-            instance = queryset.first()
-
-        with self.assertNumQueries(0):
-            result = project(instance)
-
-        self.assertEqual(
-            result, {"name_alias": "test owner", "widgets": [{"alias": "test widget"}]}
-        )
-
     def test_select_related(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test widget", owner=owner)
@@ -479,9 +527,15 @@ class PairsTestCase(TestCase):
                     qs.include_fields("owner__name"),
                 )
             ),
-            pairs.field("name"),
+            pairs.wrap_producer("name", pairs.field("name")),
             pairs.project_only(
-                projectors.relationship("owner", projectors.attr("name"))
+                projectors.wrap_producer(
+                    "owner",
+                    producers.relationship(
+                        "owner",
+                        projectors.wrap_producer("name", producers.attr("name")),
+                    ),
+                )
             ),
         )
 
@@ -503,7 +557,9 @@ class FieldDisplayTestCase(TestCase):
     def test_field_display(self):
         Thing.objects.create(size="L")
         Thing.objects.create(size="S")
-        prepare, project = pairs.field_display("size")
+        prepare, project = pairs.wrap_producer(
+            "size_display", pairs.field_display("size")
+        )
         queryset = prepare(Thing.objects.order_by("size"))
         result = [project(item) for item in queryset]
         self.assertEqual(
@@ -522,7 +578,7 @@ class FilterTestCase(TestCase):
 
         prepare, project = pairs.combine(
             pairs.filter(name="first"),
-            pairs.field("name"),
+            pairs.wrap_producer("name", pairs.field("name")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -538,7 +594,7 @@ class ExcludeTestCase(TestCase):
 
         prepare, project = pairs.combine(
             pairs.exclude(name="first"),
-            pairs.field("name"),
+            pairs.wrap_producer("name", pairs.field("name")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -555,7 +611,7 @@ class OrderByTestCase(TestCase):
 
         prepare, project = pairs.combine(
             pairs.order_by("name"),
-            pairs.field("name"),
+            pairs.wrap_producer("name", pairs.field("name")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -570,7 +626,9 @@ class PKListTestCase(TestCase):
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        prepare, project = pairs.pk_list("widget_set")
+        prepare, project = pairs.wrap_producer(
+            "widget_set", pairs.pk_list("widget_set")
+        )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
@@ -582,7 +640,9 @@ class PKListTestCase(TestCase):
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        prepare, project = pairs.pk_list("widget_set", to_attr="widgets")
+        prepare, project = pairs.wrap_producer(
+            "widgets", pairs.pk_list("widget_set", to_attr="widgets")
+        )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
@@ -596,7 +656,7 @@ class CountTestCase(TestCase):
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        prepare, project = pairs.count("widget")
+        prepare, project = pairs.wrap_producer("widget_count", pairs.count("widget"))
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
@@ -607,7 +667,7 @@ class HasTestCase(TestCase):
     def test_has_false(self):
         Owner.objects.create(name="test owner")
 
-        prepare, project = pairs.has("widget")
+        prepare, project = pairs.wrap_producer("has_widget", pairs.has("widget"))
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
@@ -617,7 +677,7 @@ class HasTestCase(TestCase):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test", owner=owner)
 
-        prepare, project = pairs.has("widget")
+        prepare, project = pairs.wrap_producer("has_widget", pairs.has("widget"))
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -10,8 +10,8 @@ class PairsTestCase(TestCase):
             Widget.objects.create(name=name, other=f"other-{name}")
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer("other", pairs.field("other")),
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector("other", pairs.field("other")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -31,10 +31,10 @@ class PairsTestCase(TestCase):
         Widget.objects.create(name=None, other=None)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer(
+            pairs.producer_to_projector(
                 "name", pairs.field("name", transform_value=title_and_reverse)
             ),
-            pairs.wrap_producer(
+            pairs.producer_to_projector(
                 "other",
                 pairs.field(
                     "other",
@@ -61,20 +61,22 @@ class PairsTestCase(TestCase):
         Widget.objects.create(name="test widget", owner=owner)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "owner",
                 pairs.forward_relationship(
                     "owner",
                     Owner.objects.all(),
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "group",
                             pairs.forward_relationship(
                                 "group",
                                 Group.objects.all(),
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                             ),
                         ),
                     ),
@@ -106,13 +108,13 @@ class PairsTestCase(TestCase):
         )
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "owner_attr",
                 pairs.forward_relationship(
                     "owner",
                     Owner.objects.all(),
-                    pairs.wrap_producer("name", pairs.field("name")),
+                    pairs.producer_to_projector("name", pairs.field("name")),
                     to_attr="owner_attr",
                 ),
             ),
@@ -138,22 +140,24 @@ class PairsTestCase(TestCase):
         Widget.objects.create(name="widget 3", owner=owner_2)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "owner_set",
                 pairs.reverse_relationship(
                     "owner_set",
                     "group",
                     Owner.objects.all(),
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "widget_set",
                             pairs.reverse_relationship(
                                 "widget_set",
                                 "owner",
                                 Widget.objects.all(),
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                             ),
                         ),
                     ),
@@ -198,14 +202,14 @@ class PairsTestCase(TestCase):
         Owner.objects.create(name="owner 2", group=group)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "owner_set_attr",
                 pairs.reverse_relationship(
                     "owner_set",
                     "group",
                     Owner.objects.all(),
-                    pairs.wrap_producer("name", pairs.field("name")),
+                    pairs.producer_to_projector("name", pairs.field("name")),
                     to_attr="owner_set_attr",
                 ),
             ),
@@ -230,21 +234,23 @@ class PairsTestCase(TestCase):
         Thing.objects.create(name="test thing", widget=widget)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "widget",
                 pairs.forward_relationship(
                     "widget",
                     Widget.objects.all(),
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "thing",
                             pairs.reverse_relationship(
                                 "thing",
                                 "widget",
                                 Thing.objects.all(),
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                             ),
                         ),
                     ),
@@ -274,21 +280,23 @@ class PairsTestCase(TestCase):
         Thing.objects.create(name="test thing", widget=widget)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "widget_attr",
                 pairs.forward_relationship(
                     "widget",
                     Widget.objects.all(),
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "thing_attr",
                             pairs.reverse_relationship(
                                 "thing",
                                 "widget",
                                 Thing.objects.all(),
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                                 to_attr="thing_attr",
                             ),
                         ),
@@ -318,20 +326,22 @@ class PairsTestCase(TestCase):
         category.widget_set.add(widget)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "widget_set",
                 pairs.many_to_many_relationship(
                     "widget_set",
                     Widget.objects.all(),
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "category_set",
                             pairs.many_to_many_relationship(
                                 "category_set",
                                 Category.objects.all(),
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                             ),
                         ),
                     ),
@@ -364,20 +374,22 @@ class PairsTestCase(TestCase):
         category.widget_set.add(widget)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "widget_set_attr",
                 pairs.many_to_many_relationship(
                     "widget_set",
                     Widget.objects.all(),
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "category_set_attr",
                             pairs.many_to_many_relationship(
                                 "category_set",
                                 Category.objects.all(),
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                                 to_attr="category_set_attr",
                             ),
                         ),
@@ -411,50 +423,56 @@ class PairsTestCase(TestCase):
         Thing.objects.create(name="test thing", widget=widget)
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "owner",
                 pairs.relationship(
                     "owner",
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "widget_set",
                             pairs.relationship(
                                 "widget_set",
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                             ),
                         ),
                     ),
                 ),
             ),
-            pairs.wrap_producer(
+            pairs.producer_to_projector(
                 "category_set",
                 pairs.relationship(
                     "category_set",
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "widget_set",
                             pairs.relationship(
                                 "widget_set",
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                             ),
                         ),
                     ),
                 ),
             ),
-            pairs.wrap_producer(
+            pairs.producer_to_projector(
                 "thing",
                 pairs.relationship(
                     "thing",
                     pairs.combine(
-                        pairs.wrap_producer("name", pairs.field("name")),
-                        pairs.wrap_producer(
+                        pairs.producer_to_projector("name", pairs.field("name")),
+                        pairs.producer_to_projector(
                             "widget",
                             pairs.relationship(
                                 "widget",
-                                pairs.wrap_producer("name", pairs.field("name")),
+                                pairs.producer_to_projector(
+                                    "name", pairs.field("name")
+                                ),
                             ),
                         ),
                     ),
@@ -492,12 +510,12 @@ class PairsTestCase(TestCase):
         )
 
         prepare, project = pairs.combine(
-            pairs.wrap_producer("name", pairs.field("name")),
-            pairs.wrap_producer(
+            pairs.producer_to_projector("name", pairs.field("name")),
+            pairs.producer_to_projector(
                 "owner_attr",
                 pairs.relationship(
                     "owner",
-                    pairs.wrap_producer("name", pairs.field("name")),
+                    pairs.producer_to_projector("name", pairs.field("name")),
                     to_attr="owner_attr",
                 ),
             ),
@@ -527,13 +545,15 @@ class PairsTestCase(TestCase):
                     qs.include_fields("owner__name"),
                 )
             ),
-            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.producer_to_projector("name", pairs.field("name")),
             pairs.project_only(
-                projectors.wrap_producer(
+                projectors.producer_to_projector(
                     "owner",
                     producers.relationship(
                         "owner",
-                        projectors.wrap_producer("name", producers.attr("name")),
+                        projectors.producer_to_projector(
+                            "name", producers.attr("name")
+                        ),
                     ),
                 )
             ),
@@ -557,7 +577,7 @@ class FieldDisplayTestCase(TestCase):
     def test_field_display(self):
         Thing.objects.create(size="L")
         Thing.objects.create(size="S")
-        prepare, project = pairs.wrap_producer(
+        prepare, project = pairs.producer_to_projector(
             "size_display", pairs.field_display("size")
         )
         queryset = prepare(Thing.objects.order_by("size"))
@@ -578,7 +598,7 @@ class FilterTestCase(TestCase):
 
         prepare, project = pairs.combine(
             pairs.filter(name="first"),
-            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.producer_to_projector("name", pairs.field("name")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -594,7 +614,7 @@ class ExcludeTestCase(TestCase):
 
         prepare, project = pairs.combine(
             pairs.exclude(name="first"),
-            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.producer_to_projector("name", pairs.field("name")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -611,7 +631,7 @@ class OrderByTestCase(TestCase):
 
         prepare, project = pairs.combine(
             pairs.order_by("name"),
-            pairs.wrap_producer("name", pairs.field("name")),
+            pairs.producer_to_projector("name", pairs.field("name")),
         )
 
         queryset = prepare(Widget.objects.all())
@@ -626,7 +646,7 @@ class PKListTestCase(TestCase):
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        prepare, project = pairs.wrap_producer(
+        prepare, project = pairs.producer_to_projector(
             "widget_set", pairs.pk_list("widget_set")
         )
 
@@ -640,7 +660,7 @@ class PKListTestCase(TestCase):
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        prepare, project = pairs.wrap_producer(
+        prepare, project = pairs.producer_to_projector(
             "widgets", pairs.pk_list("widget_set", to_attr="widgets")
         )
 
@@ -656,7 +676,9 @@ class CountTestCase(TestCase):
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        prepare, project = pairs.wrap_producer("widget_count", pairs.count("widget"))
+        prepare, project = pairs.producer_to_projector(
+            "widget_count", pairs.count("widget")
+        )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
@@ -667,7 +689,9 @@ class HasTestCase(TestCase):
     def test_has_false(self):
         Owner.objects.create(name="test owner")
 
-        prepare, project = pairs.wrap_producer("has_widget", pairs.has("widget"))
+        prepare, project = pairs.producer_to_projector(
+            "has_widget", pairs.has("widget")
+        )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
@@ -677,7 +701,9 @@ class HasTestCase(TestCase):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test", owner=owner)
 
-        prepare, project = pairs.wrap_producer("has_widget", pairs.has("widget"))
+        prepare, project = pairs.producer_to_projector(
+            "has_widget", pairs.has("widget")
+        )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())

--- a/tests/test_producers.py
+++ b/tests/test_producers.py
@@ -1,0 +1,164 @@
+from django.test import TestCase
+from django_readers import producers, projectors
+from tests.models import Group, Owner, Widget
+
+
+def title_and_reverse(arg):
+    return str(arg).title()[::-1]
+
+
+class AttrTestCase(TestCase):
+    def test_attr(self):
+        widget = Widget.objects.create(name="test")
+        produce = producers.attr("name")
+        result = produce(widget)
+        self.assertEqual(result, "test")
+
+    def test_attr_transform_value(self):
+        widget = Widget(name="test")
+        produce = producers.attr("name", transform_value=title_and_reverse)
+        result = produce(widget)
+        self.assertEqual(result, "tseT")
+
+    def test_attr_transform_value_if_none(self):
+        widget = Widget(name=None)
+        produce = producers.attr("name", transform_value=title_and_reverse)
+        result = produce(widget)
+        self.assertEqual(result, None)
+
+        produce = producers.attr(
+            "name",
+            transform_value=lambda value: value.upper(),
+            transform_value_if_none=True,
+        )
+
+        with self.assertRaisesMessage(
+            AttributeError, "'NoneType' object has no attribute 'upper'"
+        ):
+            result = produce(widget)
+
+    def test_dotted_attr_handles_none(self):
+        widget = Widget.objects.create(name="test")
+        produce = producers.attr("owner.name")
+        result = produce(widget)
+        self.assertEqual(result, None)
+
+
+class RelationshipTestCase(TestCase):
+    def test_relationship_producer(self):
+        widget = Widget.objects.create(
+            name="test widget",
+            owner=Owner.objects.create(
+                name="test owner", group=Group.objects.create(name="test group")
+            ),
+        )
+
+        produce = producers.relationship(
+            "owner",
+            projectors.combine(
+                projectors.wrap_producer("name", producers.attr("name")),
+                projectors.wrap_producer(
+                    "group",
+                    producers.relationship(
+                        "group",
+                        projectors.wrap_producer("name", producers.attr("name")),
+                    ),
+                ),
+            ),
+        )
+
+        result = produce(widget)
+        self.assertEqual(
+            result,
+            {"name": "test owner", "group": {"name": "test group"}},
+        )
+
+    def test_nullable(self):
+        widget = Widget.objects.create(owner=None)
+        produce = producers.relationship(
+            "owner", projectors.wrap_producer("name", producers.attr("name"))
+        )
+        result = produce(widget)
+        self.assertEqual(result, None)
+
+    def test_nullable_one_to_one(self):
+        widget = Widget.objects.create(thing=None)
+        produce = producers.relationship(
+            "thing", projectors.wrap_producer("name", producers.attr("name"))
+        )
+        result = produce(widget)
+        self.assertEqual(result, None)
+
+    def test_many_relationships(self):
+        group = Group.objects.create(name="test group")
+        owner_1 = Owner.objects.create(name="owner 1", group=group)
+        owner_2 = Owner.objects.create(name="owner 2", group=group)
+        Widget.objects.create(name="widget 1", owner=owner_1)
+        Widget.objects.create(name="widget 2", owner=owner_1)
+        Widget.objects.create(name="widget 3", owner=owner_2)
+
+        produce = producers.relationship(
+            "owner_set",
+            projectors.combine(
+                projectors.wrap_producer("name", producers.attr("name")),
+                projectors.wrap_producer(
+                    "widget_set",
+                    producers.relationship(
+                        "widget_set",
+                        projectors.wrap_producer("name", producers.attr("name")),
+                    ),
+                ),
+            ),
+        )
+
+        result = produce(group)
+        self.assertEqual(
+            result,
+            [
+                {
+                    "name": "owner 1",
+                    "widget_set": [
+                        {"name": "widget 1"},
+                        {"name": "widget 2"},
+                    ],
+                },
+                {
+                    "name": "owner 2",
+                    "widget_set": [
+                        {"name": "widget 3"},
+                    ],
+                },
+            ],
+        )
+
+
+class MethodTestCase(TestCase):
+    def test_method_with_no_arguments(self):
+        class Widget:
+            def hello(self):
+                return "hello!"
+
+        produce = producers.method("hello")
+        result = produce(Widget())
+        self.assertEqual(result, "hello!")
+
+    def test_method_with_arguments(self):
+        class Widget:
+            def hello(self, name):
+                return f"hello, {name}!"
+
+        produce = producers.method("hello", "tester")
+        result = produce(Widget())
+        self.assertEqual(result, "hello, tester!")
+
+
+class PKListTestCase(TestCase):
+    def test_pk_list(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        produce = producers.pk_list("widget_set")
+        result = produce(owner)
+        self.assertEqual(result, [1, 2, 3])

--- a/tests/test_producers.py
+++ b/tests/test_producers.py
@@ -56,12 +56,14 @@ class RelationshipTestCase(TestCase):
         produce = producers.relationship(
             "owner",
             projectors.combine(
-                projectors.wrap_producer("name", producers.attr("name")),
-                projectors.wrap_producer(
+                projectors.producer_to_projector("name", producers.attr("name")),
+                projectors.producer_to_projector(
                     "group",
                     producers.relationship(
                         "group",
-                        projectors.wrap_producer("name", producers.attr("name")),
+                        projectors.producer_to_projector(
+                            "name", producers.attr("name")
+                        ),
                     ),
                 ),
             ),
@@ -76,7 +78,7 @@ class RelationshipTestCase(TestCase):
     def test_nullable(self):
         widget = Widget.objects.create(owner=None)
         produce = producers.relationship(
-            "owner", projectors.wrap_producer("name", producers.attr("name"))
+            "owner", projectors.producer_to_projector("name", producers.attr("name"))
         )
         result = produce(widget)
         self.assertEqual(result, None)
@@ -84,7 +86,7 @@ class RelationshipTestCase(TestCase):
     def test_nullable_one_to_one(self):
         widget = Widget.objects.create(thing=None)
         produce = producers.relationship(
-            "thing", projectors.wrap_producer("name", producers.attr("name"))
+            "thing", projectors.producer_to_projector("name", producers.attr("name"))
         )
         result = produce(widget)
         self.assertEqual(result, None)
@@ -100,12 +102,14 @@ class RelationshipTestCase(TestCase):
         produce = producers.relationship(
             "owner_set",
             projectors.combine(
-                projectors.wrap_producer("name", producers.attr("name")),
-                projectors.wrap_producer(
+                projectors.producer_to_projector("name", producers.attr("name")),
+                projectors.producer_to_projector(
                     "widget_set",
                     producers.relationship(
                         "widget_set",
-                        projectors.wrap_producer("name", producers.attr("name")),
+                        projectors.producer_to_projector(
+                            "name", producers.attr("name")
+                        ),
                     ),
                 ),
             ),

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -4,13 +4,13 @@ from tests.models import Widget
 
 
 class WrapProducerTestCase(TestCase):
-    def test_wrap_producer(self):
+    def test_producer_to_projector(self):
         widget = Widget(name="test", other="other")
 
         def produce_name(instance):
             return instance.name
 
-        project = projectors.wrap_producer("name", produce_name)
+        project = projectors.producer_to_projector("name", produce_name)
         result = project(widget)
         self.assertEqual(result, {"name": "test"})
 
@@ -19,8 +19,8 @@ class CombineTestCase(TestCase):
     def test_combine(self):
         widget = Widget.objects.create(name="test", other="other")
         project = projectors.combine(
-            projectors.wrap_producer("name", producers.attr("name")),
-            projectors.wrap_producer("other", producers.attr("other")),
+            projectors.producer_to_projector("name", producers.attr("name")),
+            projectors.producer_to_projector("other", producers.attr("other")),
         )
         result = project(widget)
         self.assertEqual(result, {"name": "test", "other": "other"})
@@ -28,7 +28,7 @@ class CombineTestCase(TestCase):
     def test_combined_error_if_dictionary_not_returned(self):
         widget = Widget.objects.create(name="test", other="other")
         project = projectors.combine(
-            projectors.wrap_producer("name", producers.attr("name")),
+            projectors.producer_to_projector("name", producers.attr("name")),
             producers.attr("other"),
         )
         with self.assertRaises(TypeError):

--- a/tests/test_projectors.py
+++ b/tests/test_projectors.py
@@ -1,199 +1,43 @@
 from django.test import TestCase
-from django_readers import projectors
-from tests.models import Group, Owner, Widget
+from django_readers import producers, projectors
+from tests.models import Widget
 
 
-def title_and_reverse(arg):
-    return str(arg).title()[::-1]
+class WrapProducerTestCase(TestCase):
+    def test_wrap_producer(self):
+        widget = Widget(name="test", other="other")
 
+        def produce_name(instance):
+            return instance.name
 
-class ProjectorTestCase(TestCase):
-    def test_attr(self):
-        widget = Widget.objects.create(name="test")
-        project = projectors.attr("name")
+        project = projectors.wrap_producer("name", produce_name)
         result = project(widget)
         self.assertEqual(result, {"name": "test"})
 
-    def test_attr_transform_value(self):
-        widget = Widget(name="test")
-        project = projectors.attr("name", transform_value=title_and_reverse)
-        result = project(widget)
-        self.assertEqual(result, {"name": "tseT"})
 
-    def test_attr_transform_value_if_none(self):
-        widget = Widget(name=None)
-        project = projectors.attr("name", transform_value=title_and_reverse)
-        result = project(widget)
-        self.assertEqual(result, {"name": None})
-
-        project = projectors.attr(
-            "name",
-            transform_value=lambda value: value.upper(),
-            transform_value_if_none=True,
-        )
-
-        with self.assertRaisesMessage(
-            AttributeError, "'NoneType' object has no attribute 'upper'"
-        ):
-            result = project(widget)
-
+class CombineTestCase(TestCase):
     def test_combine(self):
         widget = Widget.objects.create(name="test", other="other")
         project = projectors.combine(
-            projectors.attr("name"),
-            projectors.attr("other"),
+            projectors.wrap_producer("name", producers.attr("name")),
+            projectors.wrap_producer("other", producers.attr("other")),
         )
         result = project(widget)
         self.assertEqual(result, {"name": "test", "other": "other"})
 
+    def test_combined_error_if_dictionary_not_returned(self):
+        widget = Widget.objects.create(name="test", other="other")
+        project = projectors.combine(
+            projectors.wrap_producer("name", producers.attr("name")),
+            producers.attr("other"),
+        )
+        with self.assertRaises(TypeError):
+            project(widget)
+
+
+class NoOpTestCase(TestCase):
     def test_noop(self):
         widget = Widget.objects.create(name="test")
         project = projectors.noop
         result = project(widget)
         self.assertEqual(result, {})
-
-    def test_alias(self):
-        widget = Widget.objects.create(name="test")
-        project = projectors.alias({"name": "new_name"}, projectors.attr("name"))
-        result = project(widget)
-        self.assertEqual(result, {"new_name": "test"})
-
-    def test_single_alias(self):
-        widget = Widget.objects.create(name="test")
-        project = projectors.alias("new_name", projectors.attr("name"))
-        result = project(widget)
-        self.assertEqual(result, {"new_name": "test"})
-
-    def test_single_alias_with_multiple_keys(self):
-        widget = Widget.objects.create(name="test")
-
-        def projector(_):
-            return {"a": 1, "b": 2}
-
-        project = projectors.alias("aliased", projector)
-        with self.assertRaises(TypeError):
-            project(widget)
-
-    def test_dotted_attr_handles_none(self):
-        widget = Widget.objects.create(name="test")
-        project = projectors.attr("owner.name")
-        result = project(widget)
-        self.assertEqual(result, {"owner.name": None})
-
-
-class RelationshipTestCase(TestCase):
-    def test_relationship_projector(self):
-        widget = Widget.objects.create(
-            name="test widget",
-            owner=Owner.objects.create(
-                name="test owner", group=Group.objects.create(name="test group")
-            ),
-        )
-
-        project = projectors.combine(
-            projectors.attr("name"),
-            projectors.relationship(
-                "owner",
-                projectors.combine(
-                    projectors.attr("name"),
-                    projectors.relationship("group", projectors.attr("name")),
-                ),
-            ),
-        )
-
-        result = project(widget)
-        self.assertEqual(
-            result,
-            {
-                "name": "test widget",
-                "owner": {"name": "test owner", "group": {"name": "test group"}},
-            },
-        )
-
-    def test_nullable(self):
-        widget = Widget.objects.create(owner=None)
-        project = projectors.relationship("owner", projectors.attr("name"))
-        result = project(widget)
-        self.assertEqual(result, {"owner": None})
-
-    def test_nullable_one_to_one(self):
-        widget = Widget.objects.create(thing=None)
-        project = projectors.relationship("thing", projectors.attr("name"))
-        result = project(widget)
-        self.assertEqual(result, {"thing": None})
-
-    def test_many_relationships(self):
-        group = Group.objects.create(name="test group")
-        owner_1 = Owner.objects.create(name="owner 1", group=group)
-        owner_2 = Owner.objects.create(name="owner 2", group=group)
-        Widget.objects.create(name="widget 1", owner=owner_1)
-        Widget.objects.create(name="widget 2", owner=owner_1)
-        Widget.objects.create(name="widget 3", owner=owner_2)
-
-        project = projectors.combine(
-            projectors.attr("name"),
-            projectors.relationship(
-                "owner_set",
-                projectors.combine(
-                    projectors.attr("name"),
-                    projectors.relationship("widget_set", projectors.attr("name")),
-                ),
-            ),
-        )
-
-        result = project(group)
-        self.assertEqual(
-            result,
-            {
-                "name": "test group",
-                "owner_set": [
-                    {
-                        "name": "owner 1",
-                        "widget_set": [
-                            {"name": "widget 1"},
-                            {"name": "widget 2"},
-                        ],
-                    },
-                    {
-                        "name": "owner 2",
-                        "widget_set": [
-                            {"name": "widget 3"},
-                        ],
-                    },
-                ],
-            },
-        )
-
-
-class MethodTestCase(TestCase):
-    def test_method_with_no_arguments(self):
-        class Widget:
-            def hello(self):
-                return "hello!"
-
-        project = projectors.method("hello")
-        result = project(Widget())
-        self.assertEqual(result, {"hello": "hello!"})
-
-    def test_method_with_arguments(self):
-        class Widget:
-            def hello(self, name):
-                return f"hello, {name}!"
-
-        project = projectors.method("hello", "tester")
-        result = project(Widget())
-        self.assertEqual(result, {"hello": "hello, tester!"})
-
-
-class PKListTestCase(TestCase):
-    def test_pk_list(self):
-        owner = Owner.objects.create(name="test owner")
-        Widget.objects.create(name="test 1", owner=owner)
-        Widget.objects.create(name="test 2", owner=owner)
-        Widget.objects.create(name="test 3", owner=owner)
-
-        project = projectors.pk_list("widget_set")
-
-        result = project(owner)
-
-        self.assertEqual(result, {"widget_set": [1, 2, 3]})

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -105,33 +105,6 @@ class SpecTestCase(TestCase):
             },
         )
 
-    def test_alias(self):
-        owner = Owner.objects.create(name="test owner")
-        Widget.objects.create(name="test widget", owner=owner)
-
-        prepare, project = specs.process(
-            [
-                specs.alias({"name": "name_alias"}, "name"),
-                specs.alias(
-                    "widgets",
-                    {"widget_set": [specs.alias("alias", "name")]},
-                ),
-            ]
-        )
-
-        with self.assertNumQueries(0):
-            queryset = prepare(Owner.objects.all())
-
-        with self.assertNumQueries(2):
-            instance = queryset.first()
-
-        with self.assertNumQueries(0):
-            result = project(instance)
-
-        self.assertEqual(
-            result, {"name_alias": "test owner", "widgets": [{"alias": "test widget"}]}
-        )
-
     def test_relationship_function(self):
         Widget.objects.create(
             name="test widget", owner=Owner.objects.create(name="test owner")

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -126,7 +126,7 @@ class SpecTestCase(TestCase):
             {"name": "test widget", "owner_attr": {"name": "test owner"}},
         )
 
-    def test_wrap_producer_shortcut(self):
+    def test_producer_to_projector_shortcut(self):
         Widget.objects.create(
             name="test widget",
             owner=Owner.objects.create(

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -167,3 +167,23 @@ class SpecTestCase(TestCase):
                 "aliased_value_from_pair": "some value",
             },
         )
+
+    def test_wrap_relationship_must_have_only_one_key(self):
+        Widget.objects.create(
+            name="test widget",
+            owner=Owner.objects.create(name="test owner"),
+        )
+
+        with self.assertRaises(ValueError):
+            specs.process(
+                [
+                    {
+                        "alias_for_owner_relationship": {
+                            "owner": [
+                                {"aliased_owner_name": "name"},
+                            ],
+                            "other_thing": ["whatever"],
+                        },
+                    },
+                ]
+            )


### PR DESCRIPTION
This is a big conceptual shift.

Binding the name to the value by having projectors return dictionaries turned out to not be ideal. It was conflating the lower layers (getting values from instances) with the higher layers (presenting the data) because those projector functions had to give a specific name to the value they returned. This necessitated the introducion of "aliasing" throughout the API, whereby the key returned from the projector was replaced with another one. Aliasing was just a hack around the root problem - the names should only be bound in specs.

This PR introduces the concept of "producers", which are functions which just get a single _value_ from an instance. These are then later wrapped to form projectors.

The recommended way to use `django-readers` is now to write custom _producer_ functions (rather than _projector_ functions), and then mount them explicitly in a spec under a given key:

```python
def produce_upper_name(instance):
    return instance.name.upper()


upper_name = (qs.include_fields("name"), produce_upper_name)


prepare, project = specs.process([
    {"upper_name": upper_name}
])
```

This makes the internals of the library a little bit more complicated, but the end-user experience is actually less confusing. And the only actual breaking-backwards-compatibility change (I think) is the removal of the `alias` functions.