### PR TITLE
Add Django 4 and Python 3.10 to test matrix, remove unsupported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
-        django: [2.2, 3.2, 4.0]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        django: ["2.2", "3.2", "4.0"]
         exclude:
-          - python: 3.6
-            django: 4.0
-          - python: 3.7
-            django: 4.0
+          - python: "3.6"
+            django: "4.0"
+          - python: "3.7"
+            django: "4.0"
           - python: "3.10"
-            django: 2.2
+            django: "2.2"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,15 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-        django: [2.2, 3.0, 3.1, 3.2]
+        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        django: [2.2, 3.2, 4.0]
+        exclude:
+          - python: 3.6
+            django: 4.0
+          - python: 3.7
+            django: 4.0
+          - python: "3.10"
+            django: 2.2
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ django-readers
 
 **A lightweight function-oriented toolkit for better organisation of business logic and efficient selection and projection of data in Django projects.**
 
-Tested against Django 2.2 - 3.2 on Python 3.6 - 3.9.
+Tested against Django 2.2, 3.2 and 4.0 on Python 3.6, 3.7, 3.8, 3.9 and 3.10
 
 ![Build Status](https://github.com/dabapps/django-readers/workflows/CI/badge.svg)
 [![pypi release](https://img.shields.io/pypi/v/django-readers.svg)](https://pypi.python.org/pypi/django-readers)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ black==20.8b1
 flake8==3.8.4
 isort==5.7.0
 djangorestframework==3.12.4
+pytz==2021.3


### PR DESCRIPTION
Supercedes #45 

Not sure why I needed to add `pytz` to the dev requirements. This worked fine on Django 4 alpha, beta and RC. It's depended on by DRF, I think.