### PR TITLE
Bump versions of dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
-black==20.8b1
-flake8==3.8.4
-isort==5.7.0
-djangorestframework==3.12.4
+black==22.1.0
+flake8==4.0.1
+isort==5.10.1
+djangorestframework==3.13.1
 pytz==2021.3


### PR DESCRIPTION
The main reason for doing this is upgrading to the first non-beta version of Black 🎉 

https://black.readthedocs.io/en/stable/change_log.html