### PR TITLE
Producer and projector for grabbing the value of a related field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- New `producers.related_field` and `pairs.related_field` functions for fetching the value of any field from a related object or objects.
+
 ## [1.0.0] - 2020-10-13
 
 Initial stable release.

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Note that `django-readers` _always_ uses `prefetch_related` to load relationship
 
 Of course, it is quite possible to use `select_related` by applying `qs.select_related` at the root of your query, but this must be done manually. `django-readers` also provides `qs.select_related_fields`, which combines `select_related` with `include_fields` to allow you to specify exactly which fields you need from the related objects.
 
-You can use `pairs.pk_list` to produce a list containing just the primary keys of the related objects.
+You can use `pairs.pk_list` to produce a list containing just the primary keys of the related objects. A more general form of this function is `pairs.related_field`, which returns the value (or a list of the values) of any field from a related objects or objects.
 
 As a shortcut, the `pairs` module provides functions called `filter`, `exclude` and `order_by`, which can be used to apply the given queryset functions to the queryset _without affecting the projection_. These are equivalent to (for example) `(qs.filter(arg=value), projectors.noop)` and are most useful for filtering or ordering related objects:
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -111,6 +111,17 @@ def relationship(name, relationship_pair, to_attr=None):
     return prepare, producers.relationship(to_attr or name, project_relationship)
 
 
+def field_list(relationship_name, field_name, to_attr=None):
+    return (
+        qs.auto_prefetch_relationship(
+            relationship_name,
+            qs.include_fields(field_name),
+            to_attr=to_attr,
+        ),
+        producers.field_list(to_attr or relationship_name, field_name),
+    )
+
+
 def pk_list(name, to_attr=None):
     return (
         qs.auto_prefetch_relationship(name, qs.include_fields("pk"), to_attr=to_attr),

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -122,5 +122,5 @@ def field_list(relationship_name, field_name, to_attr=None):
     )
 
 
-def pk_list(name, to_attr=None):
-    return field_list(name, "pk", to_attr=to_attr)
+def pk_list(relationship_name, to_attr=None):
+    return field_list(relationship_name, "pk", to_attr=to_attr)

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -111,16 +111,16 @@ def relationship(name, relationship_pair, to_attr=None):
     return prepare, producers.relationship(to_attr or name, project_relationship)
 
 
-def related_field_value(relationship_name, field_name, to_attr=None):
+def related_field(relationship_name, field_name, to_attr=None):
     return (
         qs.auto_prefetch_relationship(
             relationship_name,
             qs.include_fields(field_name),
             to_attr=to_attr,
         ),
-        producers.related_field_value(to_attr or relationship_name, field_name),
+        producers.related_field(to_attr or relationship_name, field_name),
     )
 
 
 def pk_list(relationship_name, to_attr=None):
-    return related_field_value(relationship_name, "pk", to_attr=to_attr)
+    return related_field(relationship_name, "pk", to_attr=to_attr)

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -111,16 +111,16 @@ def relationship(name, relationship_pair, to_attr=None):
     return prepare, producers.relationship(to_attr or name, project_relationship)
 
 
-def field_list(relationship_name, field_name, to_attr=None):
+def related_field_value(relationship_name, field_name, to_attr=None):
     return (
         qs.auto_prefetch_relationship(
             relationship_name,
             qs.include_fields(field_name),
             to_attr=to_attr,
         ),
-        producers.field_list(to_attr or relationship_name, field_name),
+        producers.related_field_value(to_attr or relationship_name, field_name),
     )
 
 
 def pk_list(relationship_name, to_attr=None):
-    return field_list(relationship_name, "pk", to_attr=to_attr)
+    return related_field_value(relationship_name, "pk", to_attr=to_attr)

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -123,7 +123,4 @@ def field_list(relationship_name, field_name, to_attr=None):
 
 
 def pk_list(name, to_attr=None):
-    return (
-        qs.auto_prefetch_relationship(name, qs.include_fields("pk"), to_attr=to_attr),
-        producers.pk_list(to_attr or name),
-    )
+    return field_list(name, "pk", to_attr=to_attr)

--- a/django_readers/producers.py
+++ b/django_readers/producers.py
@@ -49,4 +49,4 @@ def pk_list(name):
     just a single PK if this is a to-one field, but this is an inefficient way of
     doing it).
     """
-    return relationship(name, attrgetter("pk"))
+    return field_list(name, "pk")

--- a/django_readers/producers.py
+++ b/django_readers/producers.py
@@ -42,11 +42,11 @@ def field_list(relationship_name, field_name):
     return relationship(relationship_name, attrgetter(field_name))
 
 
-def pk_list(name):
+def pk_list(relationship_name):
     """
     Given an attribute name (which should be a relationship field), return a
     producer which returns a list of the PK of each item in the relationship (or
     just a single PK if this is a to-one field, but this is an inefficient way of
     doing it).
     """
-    return field_list(name, "pk")
+    return field_list(relationship_name, "pk")

--- a/django_readers/producers.py
+++ b/django_readers/producers.py
@@ -34,6 +34,14 @@ def relationship(name, related_projector):
     return producer
 
 
+def field_list(relationship_name, field_name):
+    """
+    Given a relationship name and the name of a field, return a producer which returns
+    a list containing the value of that field for each object in the relationship
+    """
+    return relationship(relationship_name, attrgetter(field_name))
+
+
 def pk_list(name):
     """
     Given an attribute name (which should be a relationship field), return a

--- a/django_readers/producers.py
+++ b/django_readers/producers.py
@@ -34,7 +34,7 @@ def relationship(name, related_projector):
     return producer
 
 
-def field_list(relationship_name, field_name):
+def related_field_value(relationship_name, field_name):
     """
     Given a relationship name and the name of a field, return a producer which returns
     a list containing the value of that field for each object in the relationship
@@ -49,4 +49,4 @@ def pk_list(relationship_name):
     just a single PK if this is a to-one field, but this is an inefficient way of
     doing it).
     """
-    return field_list(relationship_name, "pk")
+    return related_field_value(relationship_name, "pk")

--- a/django_readers/producers.py
+++ b/django_readers/producers.py
@@ -34,7 +34,7 @@ def relationship(name, related_projector):
     return producer
 
 
-def related_field_value(relationship_name, field_name):
+def related_field(relationship_name, field_name):
     """
     Given a relationship name and the name of a field, return a producer which returns
     a list containing the value of that field for each object in the relationship
@@ -49,4 +49,4 @@ def pk_list(relationship_name):
     just a single PK if this is a to-one field, but this is an inefficient way of
     doing it).
     """
-    return related_field_value(relationship_name, "pk")
+    return related_field(relationship_name, "pk")

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -639,22 +639,22 @@ class OrderByTestCase(TestCase):
         self.assertEqual(result, [{"name": "a"}, {"name": "b"}, {"name": "c"}])
 
 
-class RelatedFieldValueTestCase(TestCase):
-    def test_related_field_value(self):
+class RelatedFieldTestCase(TestCase):
+    def test_related_field(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test 1", owner=owner)
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
         prepare, project = pairs.producer_to_projector(
-            "widget_set", pairs.related_field_value("widget_set", "name")
+            "widget_set", pairs.related_field("widget_set", "name")
         )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
         self.assertEqual(result, {"widget_set": ["test 1", "test 2", "test 3"]})
 
-    def test_related_field_value_with_to_attr(self):
+    def test_related_field_with_to_attr(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test 1", owner=owner)
         Widget.objects.create(name="test 2", owner=owner)
@@ -662,19 +662,19 @@ class RelatedFieldValueTestCase(TestCase):
 
         prepare, project = pairs.producer_to_projector(
             "widgets",
-            pairs.related_field_value("widget_set", "name", to_attr="widgets"),
+            pairs.related_field("widget_set", "name", to_attr="widgets"),
         )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
         self.assertEqual(result, {"widgets": ["test 1", "test 2", "test 3"]})
 
-    def test_related_field_value_single_object(self):
+    def test_related_field_single_object(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test widget", owner=owner)
 
         prepare, project = pairs.producer_to_projector(
-            "owner_name", pairs.related_field_value("owner", "name")
+            "owner_name", pairs.related_field("owner", "name")
         )
 
         queryset = prepare(Widget.objects.all())

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -639,6 +639,36 @@ class OrderByTestCase(TestCase):
         self.assertEqual(result, [{"name": "a"}, {"name": "b"}, {"name": "c"}])
 
 
+class FieldListTestCase(TestCase):
+    def test_field_list(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        prepare, project = pairs.producer_to_projector(
+            "widget_set", pairs.field_list("widget_set", "name")
+        )
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widget_set": ["test 1", "test 2", "test 3"]})
+
+    def test_field_list_with_to_attr(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        prepare, project = pairs.producer_to_projector(
+            "widgets", pairs.field_list("widget_set", "name", to_attr="widgets")
+        )
+
+        queryset = prepare(Owner.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"widgets": ["test 1", "test 2", "test 3"]})
+
+
 class PKListTestCase(TestCase):
     def test_pk_list(self):
         owner = Owner.objects.create(name="test owner")

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -639,29 +639,30 @@ class OrderByTestCase(TestCase):
         self.assertEqual(result, [{"name": "a"}, {"name": "b"}, {"name": "c"}])
 
 
-class FieldListTestCase(TestCase):
-    def test_field_list(self):
+class RelatedFieldValueTestCase(TestCase):
+    def test_related_field_value(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test 1", owner=owner)
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
         prepare, project = pairs.producer_to_projector(
-            "widget_set", pairs.field_list("widget_set", "name")
+            "widget_set", pairs.related_field_value("widget_set", "name")
         )
 
         queryset = prepare(Owner.objects.all())
         result = project(queryset.first())
         self.assertEqual(result, {"widget_set": ["test 1", "test 2", "test 3"]})
 
-    def test_field_list_with_to_attr(self):
+    def test_related_field_value_with_to_attr(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test 1", owner=owner)
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
         prepare, project = pairs.producer_to_projector(
-            "widgets", pairs.field_list("widget_set", "name", to_attr="widgets")
+            "widgets",
+            pairs.related_field_value("widget_set", "name", to_attr="widgets"),
         )
 
         queryset = prepare(Owner.objects.all())

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -669,6 +669,18 @@ class RelatedFieldValueTestCase(TestCase):
         result = project(queryset.first())
         self.assertEqual(result, {"widgets": ["test 1", "test 2", "test 3"]})
 
+    def test_related_field_value_single_object(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test widget", owner=owner)
+
+        prepare, project = pairs.producer_to_projector(
+            "owner_name", pairs.related_field_value("owner", "name")
+        )
+
+        queryset = prepare(Widget.objects.all())
+        result = project(queryset.first())
+        self.assertEqual(result, {"owner_name": "test owner"})
+
 
 class PKListTestCase(TestCase):
     def test_pk_list(self):

--- a/tests/test_producers.py
+++ b/tests/test_producers.py
@@ -156,14 +156,14 @@ class MethodTestCase(TestCase):
         self.assertEqual(result, "hello, tester!")
 
 
-class RelatedFieldValueTestCase(TestCase):
-    def test_related_field_value(self):
+class RelatedFieldTestCase(TestCase):
+    def test_related_field(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test 1", owner=owner)
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        produce = producers.related_field_value("widget_set", "name")
+        produce = producers.related_field("widget_set", "name")
         result = produce(owner)
         self.assertEqual(result, ["test 1", "test 2", "test 3"])
 

--- a/tests/test_producers.py
+++ b/tests/test_producers.py
@@ -156,6 +156,18 @@ class MethodTestCase(TestCase):
         self.assertEqual(result, "hello, tester!")
 
 
+class FieldListTestCase(TestCase):
+    def test_field_list(self):
+        owner = Owner.objects.create(name="test owner")
+        Widget.objects.create(name="test 1", owner=owner)
+        Widget.objects.create(name="test 2", owner=owner)
+        Widget.objects.create(name="test 3", owner=owner)
+
+        produce = producers.field_list("widget_set", "name")
+        result = produce(owner)
+        self.assertEqual(result, ["test 1", "test 2", "test 3"])
+
+
 class PKListTestCase(TestCase):
     def test_pk_list(self):
         owner = Owner.objects.create(name="test owner")

--- a/tests/test_producers.py
+++ b/tests/test_producers.py
@@ -156,14 +156,14 @@ class MethodTestCase(TestCase):
         self.assertEqual(result, "hello, tester!")
 
 
-class FieldListTestCase(TestCase):
-    def test_field_list(self):
+class RelatedFieldValueTestCase(TestCase):
+    def test_related_field_value(self):
         owner = Owner.objects.create(name="test owner")
         Widget.objects.create(name="test 1", owner=owner)
         Widget.objects.create(name="test 2", owner=owner)
         Widget.objects.create(name="test 3", owner=owner)
 
-        produce = producers.field_list("widget_set", "name")
+        produce = producers.related_field_value("widget_set", "name")
         result = produce(owner)
         self.assertEqual(result, ["test 1", "test 2", "test 3"])
 


### PR DESCRIPTION
This generalises the `pk_list` functions (which were added specially to sort-of replace a feature that existed in SSM) to allow fetching the value or values of _any_ field from a related object or objects.

Example:

```
prepare, project = specs.process([
    "title",
    {"author_names": pairs.related_field("author_set", "name")},
    {"publisher_name": pairs.related_field("publisher", "name")},
])

queryset = prepare(Book.objects.all())
result = project(queryset.first())
```

```
{
    "title": "django-readers for dummies",
    "author_names": ["Jamie", "PMG"],
    "publisher_name": "DabApps Press"
}
```

The existing `pk_list` functions have been refactored to use `related_field`.