### PR TITLE
SpecMixin now overrides get_queryset, not filter_queryset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `SpecMixin` now applies prepare function in `get_queryset`, not `filter_queryset`
+
 ## [1.0.0] - 2020-10-13
 
 Initial stable release.

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -40,8 +40,8 @@ class SpecMixin:
     def project(self):
         return self.reader_pair[1]
 
-    def filter_queryset(self, queryset):
-        queryset = super().filter_queryset(queryset)
+    def get_queryset(self):
+        queryset = super().get_queryset()
         return self.prepare(queryset)
 
     def get_serializer_class(self):


### PR DESCRIPTION
`filter_queryset` is specifically part of REST framework's [generic filtering](https://www.django-rest-framework.org/api-guide/filtering/#custom-generic-filtering) interface, and so using it as the point where the `SpecMixin` "hooks in" and applies the `prepare` function was a bit weird. Instead, we now override `get_queryset`, which is simpler and more idiomatic.

This also fixes a bug: if you were using `OrderingFilter` but your spec _also_ contained a pair whose `prepare` function orders the queryset in some way, then previously the `OrderingFilter` didn't have any effect, because `SpecMixin`'s `filter_queryset` happened _after_ the base `filter_queryset` was called. Now, because we no longer override `filter_queryset`, the `OrderingFilter` is able to do its stuff to the already-prepared queryset.