### PR TITLE
Add annotate pair function and refactor count and has to use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BACKWARDS INCOMPATIBLE**: The default value of the `distinct` argument for the `pairs.count` and `pairs.has` functions has changed from `True` to `False`. This now matches the default value of the `distinct` arguments to Django's `Count` annotation. To retain current behaviour, add `distinct=True` to all calls to these two functions in your codebase. For background on this decision, see [this discussion](https://github.com/dabapps/django-readers/discussions/66).
+
 ## [1.1.0] - 2022-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BACKWARDS INCOMPATIBLE**: The default value of the `distinct` argument for the `pairs.count` and `pairs.has` functions has changed from `True` to `False`. This now matches the default value of the `distinct` arguments to Django's `Count` annotation. To retain current behaviour, add `distinct=True` to all calls to these two functions in your codebase. For background on this decision, see [this discussion](https://github.com/dabapps/django-readers/discussions/66).
 
+### Added
+- New `pairs.annotate` function allowing you to annotate a queryset with aggregates, functions etc and produce the result.
+
 ## [1.1.0] - 2022-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ By convention, to help with readability, it is sensible to put pairs that don't 
 
 The `pairs.field_display` function takes the field name as its single argument and returns a pair which loads the field from the database, and then produces the result of calling `get_<field>_display`.
 
-Finally, the `pairs` module provides a function `annotate`, allowing you to annotate a queryset with aggregates, functions etc and project the result. `pairs.count` and `pairs.has` provide shortcuts to annotate a queryset with the count or existence of related objects, and produce these values.
+Finally, the `pairs` module provides a function `annotate`, allowing you to annotate a queryset with aggregates, functions etc and produce the result. `pairs.count` and `pairs.has` provide shortcuts to annotate a queryset with the count or existence of related objects, and produce these values.
 
 ### `django_readers.specs`: a high-level specification for efficient data querying and projection
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ By convention, to help with readability, it is sensible to put pairs that don't 
 
 The `pairs.field_display` function takes the field name as its single argument and returns a pair which loads the field from the database, and then produces the result of calling `get_<field>_display`.
 
-Finally, `pairs.count` and `pairs.has` provide shortcuts to annotate a queryset with the count or existence of related objects, and produce these values.
+Finally, the `pairs` module provides a function `annotate`, allowing you to annotate a queryset with aggregates, functions etc and project the result. `pairs.count` and `pairs.has` provide shortcuts to annotate a queryset with the count or existence of related objects, and produce these values.
 
 ### `django_readers.specs`: a high-level specification for efficient data querying and projection
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -43,8 +43,8 @@ def annotate(*args, **kwargs):
     """
     Return a pair that adds an annotation to the queryset and produces the value. Like
     the annotate method on QuerySet, this can take either a positional argument or a
-    keyword argument. Unlike the annotate method, this can only take a single one at a
-    time. Also, this function can optionally take transform_value and
+    keyword argument. Unlike the annotate method, this can only handle a single
+    annotation at a time. Also, this function can optionally take transform_value and
     tranform_value_if_none arguments, which are passed to the producer.
     """
     transform_value = kwargs.pop("transform_value", None)

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -67,11 +67,20 @@ def annotate(*args, **kwargs):
 
 
 def count(name, distinct=True):
-    return annotate(Count(name, distinct=distinct))
+    return annotate(
+        **{
+            f"{name}_count": Count(name, distinct=distinct),
+        }
+    )
 
 
 def has(name, distinct=True):
-    return annotate(Count(name, distinct=distinct), transform_value=bool)
+    return annotate(
+        **{
+            f"{name}_count": Count(name, distinct=distinct),
+        },
+        transform_value=bool,
+    )
 
 
 def filter(*args, **kwargs):

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -51,7 +51,7 @@ def annotate(*args, **kwargs):
     transform_value_if_none = kwargs.pop("transform_value_if_none", False)
 
     if len(args) + len(kwargs) != 1:
-        raise ValueError("Provide only a single annotation")
+        raise ValueError("Only a single annotation is supported")
 
     annotations = kwargs or {args[0].default_alias: args[0]}
     name, annotation = next(iter(annotations.items()))

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -67,20 +67,11 @@ def annotate(*args, **kwargs):
 
 
 def count(name, distinct=True):
-    return annotate(
-        **{
-            f"{name}_count": Count(name, distinct=distinct),
-        }
-    )
+    return annotate(Count(name, distinct=distinct))
 
 
 def has(name, distinct=True):
-    return annotate(
-        **{
-            f"{name}_count": Count(name, distinct=distinct),
-        },
-        transform_value=bool,
-    )
+    return annotate(Count(name, distinct=distinct), transform_value=bool)
 
 
 def filter(*args, **kwargs):

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -66,20 +66,15 @@ def annotate(*args, **kwargs):
     )
 
 
-def count(name, distinct=True):
+def count(name, *args, **kwargs):
     return annotate(
-        **{
-            f"{name}_count": Count(name, distinct=distinct),
-        }
+        **{f"{name}_count": Count(name, *args, **kwargs)},
     )
 
 
-def has(name, distinct=True):
+def has(name, *args, **kwargs):
     return annotate(
-        **{
-            f"{name}_count": Count(name, distinct=distinct),
-        },
-        transform_value=bool,
+        **{f"{name}_count": Count(name, *args, **kwargs)}, transform_value=bool
     )
 
 


### PR DESCRIPTION
Note: this PR includes a backwards-incompatible change and as such will necessitate a 2.0 release. See [this discussion](https://github.com/dabapps/django-readers/discussions/66) for details.

The new docs branch (#59) will need to be updated to include this new function.

This exposes a general purpose `annotate` function under `pairs` which closely mirrors the `annotate` method on `QuerySet`, and sits below the existing `count` and `has` shortcut pair functions (and the soon-to-exist [sum](https://github.com/dabapps/django-readers/pull/55) function).

If you're doing custom things with annotations, it replaces this:

```python
spec = [
    ...,
    {
        "fiction_book_count": (
            qs.annotate(
                fiction_book_count=Count("book", filter=Q(book__is_fiction=True))
            ),
            producers.attr("fiction_book_count"),
        )
    },
    ...,
]
```

with this:

```python
spec = [
    ...,
    {
        "fiction_book_count": pairs.annotate(
            fiction_book_count=Count("book", filter=Q(book__is_fiction=True))
        )
    },
    ...,
]
```

This feels more "Django" than our own `count`, `has`, `sum` functions, at the expensive of slightly more code and an additional import (the aggregate objects such as `Count`).