### PR TITLE
Spec-to-serializer

### DIFF
--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -151,7 +151,7 @@ class PairWithOutputField(tuple):
     output_field = serializers.ReadOnlyField()
 
 
-def set_output_field(output_field):
+def output_field(output_field):
     if not isinstance(output_field, serializers.Field):
         raise TypeError("output_field must be an instance of Field")
 
@@ -174,4 +174,4 @@ class out:
         self.output_field = output_field
 
     def __rrshift__(self, other):
-        return set_output_field(self.output_field)(other)
+        return output_field(self.output_field)(other)

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -121,9 +121,7 @@ class _CallWithRequestVisitor(SpecVisitor):
         self.request = request
 
     def visit_callable(self, fn):
-        if getattr(fn, "call_with_request", False):
-            return fn(self.request)
-        return fn
+        return fn(self.request)
 
 
 class SpecMixin:
@@ -194,8 +192,3 @@ class out:
 
     def __rrshift__(self, other):
         return output_field(self.output_field)(other)
-
-
-def call_with_request(fn):
-    fn.call_with_request = True
-    return fn

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -124,7 +124,8 @@ def spec_to_serializer_class(serializer_name, model, spec, is_root=True):
     if is_root:
         bases = (_ToRepresentationMixin,) + bases
 
-    return type(serializer_name, bases, visitor.fields)
+    meta = type("Meta", (), {"model": model})
+    return type(serializer_name, bases, {"Meta": meta, **visitor.fields})
 
 
 class _CallWithRequestVisitor(SpecVisitor):
@@ -168,7 +169,10 @@ class SpecMixin:
 
     def get_serializer_class(self):
         name = self.__class__.__name__.replace("View", "") + "Serializer"
-        model = getattr(getattr(self, "queryset", None), "model", None)
+        if hasattr(self, "model"):
+            model = self.model
+        else:
+            model = getattr(getattr(self, "queryset", None), "model", None)
         return spec_to_serializer_class(name, model, self.spec)
 
     def get_serializer_context(self):

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -118,5 +118,7 @@ class SpecMixin:
 
 class WithOutputField:
     def __init__(self, pair, *, output_field):
+        if not isinstance(output_field, serializers.Field):
+            raise TypeError("output_field must be an instance of Field")
         self.pair = pair
         self.output_field = output_field

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -33,7 +33,7 @@ class _SpecToSerializerVisitor(SpecVisitor):
         # field has been explicitly overridden
         if hasattr(value, "out"):
             field = self._prepare_field(value.out)
-            self.fields[key] = field
+            self.fields[str(key)] = field
             return key, field
 
         # No explicit override, so we can use ModelSerializer

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -185,14 +185,14 @@ def output_field(output_field):
     return decorator
 
 
-def call_with_request(fn):
-    fn.call_with_request = True
-    return fn
-
-
 class out:
     def __init__(self, output_field):
         self.output_field = output_field
 
     def __rrshift__(self, other):
         return output_field(self.output_field)(other)
+
+
+def call_with_request(fn):
+    fn.call_with_request = True
+    return fn

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -146,6 +146,10 @@ class WithOutputField:
     def __init__(self, pair, *, output_field=None, needs_request=False):
         if output_field and not isinstance(output_field, serializers.Field):
             raise TypeError("output_field must be an instance of Field")
+
+        if needs_request and not callable(pair_or_fn):
+            raise TypeError("First argument must be callable if needs_request is True")
+
         self.pair = pair
         self.output_field = output_field or serializers.ReadOnlyField()
         self.needs_request = needs_request

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -68,7 +68,7 @@ def spec_to_serializer_class(serializer_name, model, spec):
         serializer_name,
         (serializers.Serializer,),
         {
-            "to_representation": lambda self, instance: self.context["view"].project(
+            "to_representation": lambda self, instance: self.context["project"](
                 instance
             ),
             **fields,
@@ -107,3 +107,6 @@ class SpecMixin:
         name = self.__class__.__name__.replace("View", "") + "Serializer"
         model = getattr(getattr(self, "queryset", None), "model", None)
         return spec_to_serializer_class(name, model, self.spec)
+
+    def get_serializer_context(self):
+        return {"project": self.project, **super().get_serializer_context()}

--- a/django_readers/rest_framework.py
+++ b/django_readers/rest_framework.py
@@ -148,7 +148,7 @@ class SpecMixin:
 
 
 class PairWithOutputField(tuple):
-    output_field = serializers.ReadOnlyField()
+    output_field = None
 
 
 def output_field(output_field):

--- a/django_readers/utils.py
+++ b/django_readers/utils.py
@@ -48,3 +48,61 @@ def queries_disabled(pair):
     prepare, project = pair
     decorator = zen_queries.queries_disabled() if zen_queries else lambda fn: fn
     return decorator(prepare), decorator(project)
+
+
+class SpecVisitor:
+    def visit(self, spec):
+        return [self.visit_item(item) for item in spec]
+
+    def visit_item(self, item):
+        if isinstance(item, str):
+            return self.visit_str(item)
+        if isinstance(item, dict):
+            return self.visit_dict(item)
+        if isinstance(item, tuple):
+            return self.visit_tuple(item)
+        if callable(item):
+            return self.visit_callable(item)
+        raise ValueError(f"Unexpected item in spec: {item}")
+
+    def visit_str(self, item):
+        return item
+
+    def visit_dict(self, item):
+        return dict(self.visit_dict_item(key, value) for key, value in item.items())
+
+    def visit_tuple(self, item):
+        return item
+
+    def visit_callable(self, item):
+        return item
+
+    def visit_dict_item(self, key, value):
+        if isinstance(value, str):
+            return self.visit_dict_item_str(key, value)
+        if isinstance(value, list):
+            return self.visit_dict_item_list(key, value)
+        if isinstance(value, dict):
+            if len(value) != 1:
+                raise ValueError("Aliased relationship spec must contain only one key")
+            return self.visit_dict_item_dict(key, value)
+        if isinstance(value, tuple):
+            return self.visit_dict_item_tuple(key, value)
+        if callable(value):
+            return self.visit_dict_item_callable(key, value)
+        raise ValueError(f"Unexpected item in spec: {key}, {value}")
+
+    def visit_dict_item_str(self, key, value):
+        return key, self.visit_str(value)
+
+    def visit_dict_item_list(self, key, value):
+        return key, self.visit(value)
+
+    def visit_dict_item_dict(self, key, value):
+        return key, self.visit_dict(value)
+
+    def visit_dict_item_tuple(self, key, value):
+        return key, self.visit_tuple(value)
+
+    def visit_dict_item_callable(self, key, value):
+        return key, self.visit_callable(value)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -286,6 +286,35 @@ class OutputFieldTestCase(TestCase):
             ],
         )
 
+    def test_output_field_with_producer_pair(self):
+        @output_field(
+            {
+                "upper_name": serializers.CharField(),
+                "name_length": serializers.IntegerField(),
+            }
+        )
+        def upper_name_and_name_length(instance):
+            return {
+                "upper_name": instance.name.upper(),
+                "name_length": len(instance.name),
+            }
+
+        spec = [
+            "name",
+            upper_name_and_name_length,
+        ]
+
+        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+
+        expected = dedent(
+            """\
+            CategorySerializer():
+                name = CharField(max_length=100, read_only=True)
+                upper_name = CharField(read_only=True)
+                name_length = IntegerField(read_only=True)"""
+        )
+        self.assertEqual(repr(cls()), expected)
+
 
 class NeedsRequestTestCase(TestCase):
     def test_call_producer_pair_with_request(self):

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -232,6 +232,20 @@ class OutputFieldTestCase(TestCase):
         )
         self.assertEqual(repr(cls()), expected)
 
+    def test_field_name_override(self):
+        spec = [
+            "name" >> out(serializers.IntegerField()),
+        ]
+
+        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+
+        expected = dedent(
+            """\
+            CategorySerializer():
+                name = IntegerField(read_only=True)"""
+        )
+        self.assertEqual(repr(cls()), expected)
+
     def test_out_raises_with_field_class(self):
         with self.assertRaises(TypeError):
             out(serializers.CharField)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,11 +1,6 @@
 from django.test import TestCase
 from django_readers import pairs
-from django_readers.rest_framework import (
-    out,
-    output_field,
-    spec_to_serializer_class,
-    SpecMixin,
-)
+from django_readers.rest_framework import out, spec_to_serializer_class, SpecMixin
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.test import APIRequestFactory
@@ -208,7 +203,7 @@ class OutputFieldTestCase(TestCase):
     def test_output_field(self):
         spec = [
             "name",
-            {"upper_name": output_field(serializers.CharField())(upper_name)},
+            {"upper_name": out(serializers.CharField())(upper_name)},
         ]
 
         cls = spec_to_serializer_class("CategorySerializer", Category, spec)
@@ -221,7 +216,7 @@ class OutputFieldTestCase(TestCase):
         )
         self.assertEqual(repr(cls()), expected)
 
-    def test_out_shortcut(self):
+    def test_out_rrshift(self):
         spec = [
             "name",
             {"upper_name": upper_name >> out(serializers.CharField())},
@@ -237,25 +232,21 @@ class OutputFieldTestCase(TestCase):
         )
         self.assertEqual(repr(cls()), expected)
 
-    def test_output_field_raises_with_field_class(self):
+    def test_out_raises_with_field_class(self):
         with self.assertRaises(TypeError):
-            output_field(serializers.CharField)(upper_name)
+            out(serializers.CharField)
 
     def test_output_field_is_ignored_when_calling_view(self):
         class WidgetListView(SpecMixin, ListAPIView):
             queryset = Widget.objects.all()
             spec = [
                 "name",
-                {"upper_name": output_field(serializers.CharField())(upper_name)},
+                {"upper_name": out(serializers.CharField())(upper_name)},
                 {
                     "owned_by": {
                         "owner": [
                             "name",
-                            {
-                                "upper_name": output_field(serializers.CharField())(
-                                    upper_name
-                                )
-                            },
+                            {"upper_name": out(serializers.CharField())(upper_name)},
                         ]
                     }
                 },
@@ -285,8 +276,8 @@ class OutputFieldTestCase(TestCase):
             ],
         )
 
-    def test_output_field_with_producer_pair(self):
-        @output_field(
+    def test_out_with_producer_pair(self):
+        @out(
             {
                 "upper_name": serializers.CharField(),
                 "name_length": serializers.IntegerField(),
@@ -325,17 +316,13 @@ class CallableTestCase(TestCase):
             spec = [
                 "name",
                 {
-                    "user_name": output_field(serializers.CharField())(user_name),
+                    "user_name": out(serializers.CharField())(user_name),
                 },
                 {
                     "owned_by": {
                         "owner": [
                             "name",
-                            {
-                                "user_name": output_field(serializers.CharField())(
-                                    user_name
-                                )
-                            },
+                            {"user_name": out(serializers.CharField())(user_name)},
                         ]
                     }
                 },

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 from django_readers import pairs
 from django_readers.rest_framework import (
-    call_with_request,
     out,
     output_field,
     spec_to_serializer_class,
@@ -316,7 +315,7 @@ class OutputFieldTestCase(TestCase):
         self.assertEqual(repr(cls()), expected)
 
 
-class NeedsRequestTestCase(TestCase):
+class CallableTestCase(TestCase):
     def test_call_producer_pair_with_request(self):
         def user_name(request):
             return lambda qs: qs, lambda _: request.user.name
@@ -326,9 +325,7 @@ class NeedsRequestTestCase(TestCase):
             spec = [
                 "name",
                 {
-                    "user_name": output_field(serializers.CharField())(
-                        call_with_request(user_name)
-                    ),
+                    "user_name": output_field(serializers.CharField())(user_name),
                 },
                 {
                     "owned_by": {
@@ -336,7 +333,7 @@ class NeedsRequestTestCase(TestCase):
                             "name",
                             {
                                 "user_name": output_field(serializers.CharField())(
-                                    call_with_request(user_name)
+                                    user_name
                                 )
                             },
                         ]
@@ -385,12 +382,12 @@ class NeedsRequestTestCase(TestCase):
             queryset = Widget.objects.all()
             spec = [
                 "name",
-                call_with_request(user_name_and_id),
+                user_name_and_id,
                 {
                     "owned_by": {
                         "owner": [
                             "name",
-                            call_with_request(user_name_and_id),
+                            user_name_and_id,
                         ]
                     }
                 },

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -284,3 +284,7 @@ class OutputFieldTestCase(TestCase):
                 }
             ],
         )
+
+    def test_output_field_raises_with_incorrect_callable(self):
+        with self.assertRaises(TypeError):
+            WithOutputField(upper_name, needs_request=True)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -150,6 +150,8 @@ class SpecToSerializerClassTestCase(TestCase):
         )
         self.assertEqual(repr(cls()), expected)
 
+
+class OutputFieldTestCase(TestCase):
     def test_output_field(self):
         spec = [
             "name",

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -3,7 +3,7 @@ from django_readers import pairs
 from django_readers.rest_framework import (
     call_with_request,
     out,
-    set_output_field,
+    output_field,
     spec_to_serializer_class,
     SpecMixin,
 )
@@ -209,7 +209,7 @@ class OutputFieldTestCase(TestCase):
     def test_output_field(self):
         spec = [
             "name",
-            {"upper_name": set_output_field(serializers.CharField())(upper_name)},
+            {"upper_name": output_field(serializers.CharField())(upper_name)},
         ]
 
         cls = spec_to_serializer_class("CategorySerializer", Category, spec)
@@ -240,20 +240,20 @@ class OutputFieldTestCase(TestCase):
 
     def test_output_field_raises_with_field_class(self):
         with self.assertRaises(TypeError):
-            set_output_field(serializers.CharField)(upper_name)
+            output_field(serializers.CharField)(upper_name)
 
     def test_output_field_is_ignored_when_calling_view(self):
         class WidgetListView(SpecMixin, ListAPIView):
             queryset = Widget.objects.all()
             spec = [
                 "name",
-                {"upper_name": set_output_field(serializers.CharField())(upper_name)},
+                {"upper_name": output_field(serializers.CharField())(upper_name)},
                 {
                     "owned_by": {
                         "owner": [
                             "name",
                             {
-                                "upper_name": set_output_field(serializers.CharField())(
+                                "upper_name": output_field(serializers.CharField())(
                                     upper_name
                                 )
                             },
@@ -297,7 +297,7 @@ class NeedsRequestTestCase(TestCase):
             spec = [
                 "name",
                 {
-                    "user_name": set_output_field(serializers.CharField())(
+                    "user_name": output_field(serializers.CharField())(
                         call_with_request(user_name)
                     ),
                 },
@@ -306,7 +306,7 @@ class NeedsRequestTestCase(TestCase):
                         "owner": [
                             "name",
                             {
-                                "user_name": set_output_field(serializers.CharField())(
+                                "user_name": output_field(serializers.CharField())(
                                     call_with_request(user_name)
                                 )
                             },

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -109,7 +109,7 @@ class SpecToSerializerClassTestCase(TestCase):
     def test_basic_spec(self):
         spec = ["name"]
 
-        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+        cls = spec_to_serializer_class("Category", Category, spec)
 
         expected = dedent(
             """\
@@ -133,15 +133,15 @@ class SpecToSerializerClassTestCase(TestCase):
             },
         ]
 
-        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+        cls = spec_to_serializer_class("Category", Category, spec)
 
         expected = dedent(
             """\
             CategorySerializer():
                 name = CharField(max_length=100, read_only=True)
-                widget_set = WidgetSetSerializer(many=True, read_only=True):
+                widget_set = CategoryWidgetSetSerializer(many=True, read_only=True):
                     name = CharField(allow_null=True, max_length=100, read_only=True, required=False)
-                    owner = OwnerSerializer(read_only=True):
+                    owner = CategoryWidgetSetOwnerSerializer(read_only=True):
                         name = CharField(max_length=100, read_only=True)"""
         )
         self.assertEqual(repr(cls()), expected)
@@ -178,24 +178,53 @@ class SpecToSerializerClassTestCase(TestCase):
             },
         ]
 
-        cls = spec_to_serializer_class("OwnerSerializer", Owner, spec)
+        cls = spec_to_serializer_class("Owner", Owner, spec)
 
         expected = dedent(
             """\
             OwnerSerializer():
                 name = CharField(max_length=100, read_only=True)
-                group = GroupSerializer(read_only=True):
+                group = OwnerGroupSerializer(read_only=True):
                     name = CharField(max_length=100, read_only=True)
-                widget_set = WidgetSetSerializer(many=True, read_only=True):
+                widget_set = OwnerWidgetSetSerializer(many=True, read_only=True):
                     name = CharField(allow_null=True, max_length=100, read_only=True, required=False)
-                    category_set = CategorySetSerializer(many=True, read_only=True):
+                    category_set = OwnerWidgetSetCategorySetSerializer(many=True, read_only=True):
                         name = CharField(max_length=100, read_only=True)
-                    thing = ThingSerializer(read_only=True):
+                    thing = OwnerWidgetSetThingSerializer(read_only=True):
                         name = CharField(max_length=100, read_only=True)
-                        related_widget = WidgetSerializer(read_only=True, source='widget'):
+                        related_widget = OwnerWidgetSetThingWidgetSerializer(read_only=True, source='widget'):
                             name = CharField(allow_null=True, max_length=100, read_only=True, required=False)"""
         )
+        self.assertEqual(repr(cls()), expected)
 
+    def test_view_get_serializer_class(self):
+        class CategoryListView(SpecMixin, ListAPIView):
+            queryset = Category.objects.all()
+            spec = [
+                "name",
+                {
+                    "widget_set": [
+                        "name",
+                        {
+                            "owner": [
+                                "name",
+                            ]
+                        },
+                    ]
+                },
+            ]
+
+        cls = CategoryListView().get_serializer_class()
+
+        expected = dedent(
+            """\
+            CategoryListSerializer():
+                name = CharField(max_length=100, read_only=True)
+                widget_set = CategoryListWidgetSetSerializer(many=True, read_only=True):
+                    name = CharField(allow_null=True, max_length=100, read_only=True, required=False)
+                    owner = CategoryListWidgetSetOwnerSerializer(read_only=True):
+                        name = CharField(max_length=100, read_only=True)"""
+        )
         self.assertEqual(repr(cls()), expected)
 
 
@@ -206,7 +235,7 @@ class OutputFieldTestCase(TestCase):
             {"upper_name": out(serializers.CharField())(upper_name)},
         ]
 
-        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+        cls = spec_to_serializer_class("Category", Category, spec)
 
         expected = dedent(
             """\
@@ -222,7 +251,7 @@ class OutputFieldTestCase(TestCase):
             {"upper_name": upper_name >> out(serializers.CharField())},
         ]
 
-        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+        cls = spec_to_serializer_class("Category", Category, spec)
 
         expected = dedent(
             """\
@@ -237,7 +266,7 @@ class OutputFieldTestCase(TestCase):
             "name" >> out(serializers.IntegerField()),
         ]
 
-        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+        cls = spec_to_serializer_class("Category", Category, spec)
 
         expected = dedent(
             """\
@@ -308,7 +337,7 @@ class OutputFieldTestCase(TestCase):
             upper_name_and_name_length,
         ]
 
-        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+        cls = spec_to_serializer_class("Category", Category, spec)
 
         expected = dedent(
             """\

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -46,6 +46,9 @@ class CategoryDetailView(SpecMixin, RetrieveAPIView):
     ]
 
 
+upper_name = pairs.field("name", transform_value=lambda value: value.upper())
+
+
 class RESTFrameworkTestCase(TestCase):
     def test_list(self):
         Widget.objects.create(
@@ -148,7 +151,6 @@ class SpecToSerializerClassTestCase(TestCase):
         self.assertEqual(repr(cls()), expected)
 
     def test_output_field(self):
-        upper_name = pairs.field("name", transform_value=lambda value: value.upper())
         spec = [
             "name",
             {
@@ -167,3 +169,7 @@ class SpecToSerializerClassTestCase(TestCase):
                 upper_name = CharField(read_only=True)"""
         )
         self.assertEqual(repr(cls()), expected)
+
+    def test_output_field_raises_with_field_class(self):
+        with self.assertRaises(TypeError):
+            WithOutputField(upper_name, output_field=serializers.CharField)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -150,6 +150,58 @@ class SpecToSerializerClassTestCase(TestCase):
         )
         self.assertEqual(repr(cls()), expected)
 
+    def test_all_relationship_types(self):
+        spec = [
+            "name",
+            {
+                "group": [
+                    "name",
+                ]
+            },
+            {
+                "widget_set": [
+                    "name",
+                    {
+                        "category_set": [
+                            "name",
+                        ]
+                    },
+                    {
+                        "thing": [
+                            "name",
+                            {
+                                "related_widget": {
+                                    "widget": [
+                                        "name",
+                                    ]
+                                }
+                            },
+                        ]
+                    },
+                ]
+            },
+        ]
+
+        cls = spec_to_serializer_class("OwnerSerializer", Owner, spec)
+
+        expected = dedent(
+            """\
+            OwnerSerializer():
+                name = CharField(max_length=100, read_only=True)
+                group = GroupSerializer(read_only=True):
+                    name = CharField(max_length=100, read_only=True)
+                widget_set = WidgetSetSerializer(many=True, read_only=True):
+                    name = CharField(allow_null=True, max_length=100, read_only=True, required=False)
+                    category_set = CategorySetSerializer(many=True, read_only=True):
+                        name = CharField(max_length=100, read_only=True)
+                    thing = ThingSerializer(read_only=True):
+                        name = CharField(max_length=100, read_only=True)
+                        related_widget = WidgetSerializer(read_only=True, source='widget'):
+                            name = CharField(allow_null=True, max_length=100, read_only=True, required=False)"""
+        )
+
+        self.assertEqual(repr(cls()), expected)
+
 
 class OutputFieldTestCase(TestCase):
     def test_output_field(self):

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,8 +1,9 @@
 from django.test import TestCase
-from django_readers.rest_framework import SpecMixin
+from django_readers.rest_framework import spec_to_serializer_class, SpecMixin
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.test import APIRequestFactory
 from tests.models import Category, Group, Owner, Widget
+from textwrap import dedent
 
 
 class WidgetListView(SpecMixin, ListAPIView):
@@ -97,3 +98,45 @@ class RESTFrameworkTestCase(TestCase):
                 ],
             },
         )
+
+
+class SpecToSerializerClassTestCase(TestCase):
+    def test_basic_spec(self):
+        spec = ["name"]
+
+        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+
+        expected = dedent(
+            """\
+            CategorySerializer():
+                name = CharField(max_length=100, read_only=True)"""
+        )
+        self.assertEqual(repr(cls()), expected)
+
+    def test_nested_spec(self):
+        spec = [
+            "name",
+            {
+                "widget_set": [
+                    "name",
+                    {
+                        "owner": [
+                            "name",
+                        ]
+                    },
+                ]
+            },
+        ]
+
+        cls = spec_to_serializer_class("CategorySerializer", Category, spec)
+
+        expected = dedent(
+            """\
+            CategorySerializer():
+                name = CharField(max_length=100, read_only=True)
+                widget_set = WidgetSetSerializer(many=True, read_only=True):
+                    name = CharField(allow_null=True, max_length=100, read_only=True, required=False)
+                    owner = OwnerSerializer(read_only=True):
+                        name = CharField(max_length=100, read_only=True)"""
+        )
+        self.assertEqual(repr(cls()), expected)


### PR DESCRIPTION
This is quite a big change, but it should be entirely backwards-compatible and optional. It's isolated to the `rest_framework` "layer" of `django-readers`. If DRF isn't being used in a project, this change won't affect anything.

Until now, the DRF layer of `django-readers` has not used Serializers at all. Instead it used a class (`ProjectionSerializer`) that quacked just enough like a real serializer to work with DRF's generic views.

The core of this change is a new utility function `spec_to_serializer_class`. Given a name prefix, a model class, and a spec, this function returns a "real" DRF serializer that is the same "shape" as the spec, including nested serializers to represent relationships.

The fields on this serializer are not actually used during request/response handling (we override `to_representation` and just project the object being serializer). Instead, the purpose of this is essentially to enable automatic schema generation (see #70) via introspection of views. But it may also make `django-readers` more compatible with any other parts of the DRF ecosystem that require actual serializer classes.

A couple of other changes are needed to enable this:

## Specifying field types

For spec fields that are simple model fields or relationships, we can use DRF's `ModelSerializer` machinery to automatically infer their types from the model. However, for custom pairs, we need a way to explicitly declare the return type. To enable this, a utility function `out` is provided. This can be used in two ways.

As a decorator:

```python
@out(serializers.CharField())
def upper_name():
    return qs.include_fields(name), lambda instance: instance.name.upper()
```

Or, with some special DSL-ish syntax, inline in a spec (for use with built-in library functions):

```python
spec = [
    "name",
    pairs.field_display("type") >> out(serialiers.CharField())
]
```

## Dynamic behaviour

Second, if a spec is in any way "dynamic" (ie depends on the request in some way), the previously documented way to handle this was to override `get_spec` on your view class and return the spec, rather than using a static `spec` property:

```python
@out(serializers.BooleanField())
def widget_is_mine(request):
    return qs.include_fields("owner"), lambda instance: instance.owner == request.user


class WidgetListView(SpecMixin, ListAPIView):
    def get_spec(self):
        return [
            "name",
            "size",
            {"is_mine": widget_is_mine(self.request)},
        ]
```

Of course, during introspection no `request` object is available, and so this approach wouldn't work. Instead, during request processing, the DRF layer in `django-readers` now pre-processes the `spec` and any callable objects it finds are automatically called and passed the `request` object. So there's no need to override `get_spec` at all:

```python
class WidgetListView(SpecMixin, ListAPIView):
    spec = [
        "name",
        "size",
        {"is_mine": widget_is_mine},
    ]
```

## TODO

Open question:

Do we actually want to avoid changing the behaviour of `SpecMixin` here at all (other than pre-processing for callables), and instead simply document `spec_to_serializer_class` as a util for use in custom `AutoSchema` subclasses? My concerns are:

* it's hard to guess how people are going to use this and so maybe trying to do anything automatically is a mistake
* it might be confusing that `get_serializer_class` returns a real Serializer, but this serializer isn't actually used during serialization
* the memory/performance overhead of constructing a `Serializer` (as opposed to the tiny "fake serializer" that we used before).

- [ ] Changelog
- [ ] Docs