### PR TITLE
Correct pairs docs

### DIFF
--- a/docs/reference/pairs.md
+++ b/docs/reference/pairs.md
@@ -41,7 +41,7 @@ For example:
 from django.db.models.functions import ExtractYear
 from django_readers import pairs
 
-prepare, project = pairs.annotate(
+prepare, produce = pairs.annotate(
     publication_year=ExtractYear("publication_date"),
 )
 queryset = prepare(Book.objects.all())


### PR DESCRIPTION
The `pairs.annotate` function returns a producer pair, not a projector pair.

Thanks @roman-certn