### PR TITLE
Add support for GenericRelation field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added support for Django's reverse generic relations (`GenericRelation` model field) ([#93](https://github.com/dabapps/django-readers/pull/93)).
+
 ## [2.1.2] - 2023-07-17
 
 ### Fixed

--- a/django_readers/qs.py
+++ b/django_readers/qs.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.fields import ReverseGenericManyToOneDescriptor
 from django.db.models import Prefetch, QuerySet
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related_descriptors import (
@@ -167,6 +168,32 @@ def prefetch_reverse_relationship(
     )
 
 
+def prefetch_reverse_generic_relationship(
+    name, related_field, related_queryset, prepare_related_queryset=noop, to_attr=None
+):
+    """
+    Efficiently prefetch a reverse generic relationship: one where the field on the "parent"
+    queryset is a `GenericRelation` field. We need to include this field in the query.
+    """
+    return pipe(
+        include_fields(name),
+        prefetch_related(
+            Prefetch(
+                name,
+                pipe(
+                    include_fields(
+                        "pk",
+                        related_field.content_type_field_name,
+                        related_field.object_id_field_name,
+                    ),
+                    prepare_related_queryset,
+                )(related_queryset),
+                to_attr,
+            )
+        ),
+    )
+
+
 def prefetch_many_to_many_relationship(
     name, related_queryset, prepare_related_queryset=noop, to_attr=None
 ):
@@ -243,6 +270,14 @@ def auto_prefetch_relationship(name, prepare_related_queryset=noop, to_attr=None
             return prefetch_many_to_many_relationship(
                 name,
                 related_queryset,
+                prepare_related_queryset,
+                to_attr,
+            )(queryset)
+        if type(related_descriptor) is ReverseGenericManyToOneDescriptor:
+            return prefetch_reverse_generic_relationship(
+                name,
+                related_descriptor.rel.field,
+                related_descriptor.field.related_model.objects.all(),
                 prepare_related_queryset,
                 to_attr,
             )(queryset)

--- a/django_readers/qs.py
+++ b/django_readers/qs.py
@@ -169,7 +169,12 @@ def prefetch_reverse_relationship(
 
 
 def prefetch_reverse_generic_relationship(
-    name, related_field, related_queryset, prepare_related_queryset=noop, to_attr=None
+    name,
+    content_type_field_name,
+    object_id_field_name,
+    related_queryset,
+    prepare_related_queryset=noop,
+    to_attr=None,
 ):
     """
     Efficiently prefetch a reverse generic relationship: one where the field on the "parent"
@@ -183,8 +188,8 @@ def prefetch_reverse_generic_relationship(
                 pipe(
                     include_fields(
                         "pk",
-                        related_field.content_type_field_name,
-                        related_field.object_id_field_name,
+                        content_type_field_name,
+                        object_id_field_name,
                     ),
                     prepare_related_queryset,
                 )(related_queryset),
@@ -276,7 +281,8 @@ def auto_prefetch_relationship(name, prepare_related_queryset=noop, to_attr=None
         if type(related_descriptor) is ReverseGenericManyToOneDescriptor:
             return prefetch_reverse_generic_relationship(
                 name,
-                related_descriptor.rel.field,
+                related_descriptor.rel.field.content_type_field_name,
+                related_descriptor.rel.field.object_id_field_name,
                 related_descriptor.field.related_model.objects.all(),
                 prepare_related_queryset,
                 to_attr,

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,15 @@
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
+
+
+class LogEntry(models.Model):
+    content_type = models.ForeignKey(
+        to="contenttypes.ContentType",
+        on_delete=models.CASCADE,
+        related_name="+",
+    )
+    object_pk = models.CharField(max_length=255)
+    event = models.CharField(max_length=100)
 
 
 class Group(models.Model):
@@ -15,6 +26,9 @@ class Widget(models.Model):
     value = models.PositiveIntegerField(default=0)
     other = models.CharField(max_length=100, null=True)
     owner = models.ForeignKey(Owner, null=True, on_delete=models.SET_NULL)
+    logs = GenericRelation(
+        LogEntry, content_type_field="content_type", object_id_field="object_pk"
+    )
 
 
 class Thing(models.Model):

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -202,12 +202,16 @@ class SpecToSerializerClassTestCase(TestCase):
                             },
                         ]
                     },
+                    {
+                        "logs": [
+                            "event",
+                        ]
+                    },
                 ]
             },
         ]
 
         cls = serializer_class_for_spec("Owner", Owner, spec)
-
         expected = dedent(
             """\
             OwnerSerializer():
@@ -221,7 +225,9 @@ class SpecToSerializerClassTestCase(TestCase):
                     thing = OwnerWidgetSetThingSerializer(read_only=True):
                         name = CharField(max_length=100, read_only=True)
                         related_widget = OwnerWidgetSetThingRelatedWidgetSerializer(allow_null=True, read_only=True, source='widget'):
-                            name = CharField(allow_null=True, max_length=100, read_only=True, required=False)"""
+                            name = CharField(allow_null=True, max_length=100, read_only=True, required=False)
+                    logs = OwnerWidgetSetLogsSerializer(allow_null=True, many=True, read_only=True):
+                        event = CharField(max_length=100, read_only=True)"""
         )
         self.assertEqual(repr(cls()), expected)
 


### PR DESCRIPTION
This adds support for Django's reverse generic relations, ie `GenericRelation` model field.