### PR TITLE
Add support for using Python types for schema generation

### DIFF
--- a/docs/reference/rest-framework.md
+++ b/docs/reference/rest-framework.md
@@ -199,3 +199,45 @@ class SomeView(SpecMixin, RetrieveAPIView):
         ...,
     ]
 ```
+
+### Using Python type annotations
+
+In simple cases, it's also possible to infer serializer field types from Python types. You can use a type object as an argument to `out` in place of a field:
+
+```python hl_lines="1"
+@out(str)
+def produce_hello_world(instance):
+    return "Hello world"
+```
+
+This works inline in a spec too:
+
+```python hl_lines="5"
+class SomeView(SpecMixin, RetrieveAPIView):
+    queryset = SomeModel.objects.all()
+    spec = [
+        ...,
+        {"genre": pairs.field_display("genre") >> out(str)},
+        ...,
+    ]
+```
+
+Or you can use a Python type hint on the producer function:
+
+```python hl_lines="1"
+def produce_hello_world(instance) -> str:
+    return "Hello world"
+```
+
+The table below shows which types are supported, and the resulting serializer field type. In all cases, adding `| None` or `Optional` will result in the `allow_null=True` argument being passed to the generated serializer field.
+
+| Type          | Serializer Field    |
+|---------------|---------------------|
+| `int`         | `IntegerField`      |
+| `str`         | `CharField`         |
+| `float`       | `FloatField`        |
+| `bool`        | `BooleanField`      |
+| `date`        | `DateField`         |
+| `datetime`    | `DateTimeField`     |
+| `time`        | `TimeField`         |
+| `timedelta`   | `DurationField`     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ markdown_extensions:
   - toc:
       permalink: true
   - attr_list
+  - tables
 
 repo_name: dabapps/django-readers
 repo_url: https://github.com/dabapps/django-readers/


### PR DESCRIPTION
This PR adds support for using Python type objects instead of serializer fields (in some circumstances) in the schema generation code.

Types can be used with the `out` decorator/function:

```python
@out(str)
def produce_hello_world(instance):
    return "Hello world"
```

This works inline in a spec too:

```python
class SomeView(SpecMixin, RetrieveAPIView):
    queryset = SomeModel.objects.all()
    spec = [
        ...,
        {"genre": pairs.field_display("genre") >> out(str)},
        ...,
    ]
```

You can also forego the `out` function entirely and use a Python type hint on the producer function:

```python
def produce_hello_world(instance) -> str:
    return "Hello world"
```

The table below shows which types are supported, and the resulting serializer field type. In all cases, adding `| None` or `Optional` will result in the `allow_null=True` argument being passed to the generated serializer field.

| Type          | Serializer Field    |
|---------------|---------------------|
| `int`         | `IntegerField`      |
| `str`         | `CharField`         |
| `float`       | `FloatField`        |
| `bool`        | `BooleanField`      |
| `date`        | `DateField`         |
| `datetime`    | `DateTimeField`     |
| `time`        | `TimeField`         |
| `timedelta`   | `DurationField`     |