### PR TITLE
 Add Python 3.13 and Django 5.2 to test matrix, drop unsupported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,29 +13,27 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
-        django: ["3.2", "4.0", "4.1", "4.2", "5.0"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        django: ["4.2", "5.1", "5.2"]
         exclude:
-          - python: "3.11"
-            django: "3.2"
-          - python: "3.11"
-            django: "4.0"
-          - python: "3.8"
-            django: "5.0"
+          - python: "3.13"
+            django: "4.2"
           - python: "3.9"
-            django: "5.0"
+            django: "5.2"
+          - python: "3.9"
+            django: "5.1"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python }}
+        python-version: ${{ matrix.python }}.*
     - name: Install package
       run: pip install -e .
     - name: Install dependencies
       run: pip install -r dev-requirements.txt
     - name: Install Django
-      run: pip install -U django==${{ matrix.django }}
+      run: pip install -U django~=${{ matrix.django }}.0
     - name: Run tests
       run: ./runtests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for using Python type objects instead of serializer fields in schema generation code ([#106](https://github.com/dabapps/django-readers/pull/106))
+- Added Django 5.2 and Python 3.13 to test matrix ([#107](https://github.com/dabapps/django-readers/pull/107))
 
 ## [2.3.0] - 2024-04-17
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ django-readers
 
 **A lightweight function-oriented toolkit for better organisation of business logic and efficient selection and projection of data in Django projects.**
 
-Tested against Django 3.2, 4.0, 4.1, 4.2 and 5.0 on Python 3.8, 3.9, 3.10 and 3.11.
+Tested against Django 4.2, 5.1 and 5.2 on Python 3.9, 3.10, 3.11, 3.12 and 3.13
 
 ![Build Status](https://github.com/dabapps/django-readers/workflows/CI/badge.svg?branch=main)
 [![pypi release](https://img.shields.io/pypi/v/django-readers.svg)](https://pypi.python.org/pypi/django-readers)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
-black==22.6.0
-flake8==4.0.1
-isort==5.10.1
-djangorestframework==3.14.0
-pytz==2022.1
+black==25.1.0
+flake8==7.2.0
+isort==6.0.1
+djangorestframework==3.16.0
+pytz==2025.2

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -7,6 +7,10 @@ from django_readers import qs
 from tests.models import Category, LogEntry, Owner, Widget
 from unittest import mock
 
+import django
+
+IS_5_2_OR_GREATER = django.VERSION >= (5, 2)
+
 
 class QuerySetTestCase(TestCase):
     def test_filter(self):
@@ -97,7 +101,7 @@ class QuerySetTestCase(TestCase):
             "FROM "
             '"tests_owner" '
             "WHERE "
-            '"tests_owner"."id" IN (1)',
+            '"tests_owner"."id" ' + ("= 1" if IS_5_2_OR_GREATER else "IN (1)"),
         )
 
         with self.assertNumQueries(0):
@@ -131,7 +135,7 @@ class QuerySetTestCase(TestCase):
             "FROM "
             '"tests_owner" '
             "WHERE "
-            '"tests_owner"."id" IN (1)',
+            '"tests_owner"."id" ' + ("= 1" if IS_5_2_OR_GREATER else "IN (1)"),
         )
 
     def test_prefetch_forward_relationship_with_to_attr(self):


### PR DESCRIPTION
Also:

* Bump some actions packages
* Bump test requirements
* Install latest point release of each tested version of Django and Python
* Work around some apparent changes to prefetch queries in Django 5.2