### PR TITLE
Add support for alias queryset method

### DIFF
--- a/django_readers/qs.py
+++ b/django_readers/qs.py
@@ -50,6 +50,13 @@ def annotate(*args, **kwargs):
     return queryset_function
 
 
+def alias(*args, **kwargs):
+    def queryset_function(queryset):
+        return include_fields("pk")(queryset.alias(*args, **kwargs))
+
+    return queryset_function
+
+
 noop = all()  # a queryset function that does nothing
 
 


### PR DESCRIPTION
Add support for `queryset.alias` method. This is exactly the same as `annotate` but does not include the field in the SELECT.

Useful for complex queries when you need to filter on an annotated field but do not want to include that field in the output.