### PR TITLE
Add docs for alias QS function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added `qs.alias` function to support the `.alias()` QuerySet method ([#109](https://github.com/dabapps/django-readers/pull/109))
 
 ## [2.4.0] - 2025-04-03
 

--- a/docs/reference/queryset-functions.md
+++ b/docs/reference/queryset-functions.md
@@ -16,6 +16,7 @@ Import like this: `from django_readers import qs`
 * `qs.only`
 * `qs.using`
 * `qs.annotate`
+* `qs.alias`
 
 These functions mirror the methods on the base `QuerySet` class that return new querysets. See [the Django documentation](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#methods-that-return-new-querysets) for an explanation of these.
 


### PR DESCRIPTION
## Summary
- document `qs.alias`
- note alias support in the changelog
