### PR TITLE
Add pairs.alias function to allow using qs.alias in a spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Added `qs.alias` function to support the `.alias()` QuerySet method ([#109](https://github.com/dabapps/django-readers/pull/109))
+- Added `qs.alias` function to support the `.alias()` QuerySet method ([#109](https://github.com/dabapps/django-readers/pull/109)).
+- Added `pairs.alias` function to support aliasing in a spec. ([#112](https://github.com/dabapps/django-readers/pull/112)).
 
 ## [2.4.0] - 2025-04-03
 

--- a/django_readers/pairs.py
+++ b/django_readers/pairs.py
@@ -96,6 +96,10 @@ def order_by(*args, **kwargs):
     return qs.order_by(*args, **kwargs), projectors.noop
 
 
+def alias(*args, **kwargs):
+    return qs.alias(*args, **kwargs), projectors.noop
+
+
 """
 Below are pair functions which return the various queryset functions that prefetch
 relationships of various types, and then produce those related objects.

--- a/docs/reference/pairs.md
+++ b/docs/reference/pairs.md
@@ -76,6 +76,10 @@ Returns a pair consisting of a [`qs.exclude`](queryset-functions.md#exclude) que
 
 Returns a pair consisting of a [`qs.order_by`](queryset-functions.md#functions-that-mirror-built-in-queryset-methods) queryset function, and a [no-op projector](projectors.md#noop). Most useful for ordering relationships.
 
+## `pairs.alias(*args, **kwargs)` {: #order_by}
+
+Returns a pair consisting of a [`qs.alias`](queryset-functions.md#functions-that-mirror-built-in-queryset-methods) queryset function, and a [no-op projector](projectors.md#noop). Most useful for creating expressions that are later used for filtering or ordering, but aren't needed in the final result.
+
 ## Relationships
 
 The following pair functions return the various [queryset functions that prefetch

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -1,4 +1,4 @@
-from django.db.models import Count
+from django.db.models import Count, F
 from django.db.models.functions import Length
 from django.test import TestCase
 from django_readers import pairs, producers, projectors, qs
@@ -641,6 +641,23 @@ class OrderByTestCase(TestCase):
         queryset = prepare(Widget.objects.all())
         result = [project(item) for item in queryset]
         self.assertEqual(result, [{"name": "a"}, {"name": "b"}, {"name": "c"}])
+
+
+class AliasTestCase(TestCase):
+    def test_alias(self):
+        Widget.objects.create(name="a", value=1)
+        Widget.objects.create(name="b", value=1)
+        Widget.objects.create(name="c", value=2)
+
+        prepare, project = pairs.combine(
+            pairs.alias(aliased_value=F("value")),
+            pairs.filter(aliased_value=1),
+            pairs.producer_to_projector("name", pairs.field("name")),
+        )
+
+        queryset = prepare(Widget.objects.all())
+        result = [project(item) for item in queryset]
+        self.assertEqual(result, [{"name": "a"}, {"name": "b"}])
 
 
 class PKListTestCase(TestCase):


### PR DESCRIPTION
Just allows easy use of `qs.alias` in a spec. Mirrors `pairs.filter`, `pairs.exclude` and `pairs.order_by` in not contributing anything to the projection.